### PR TITLE
Fix typo and translate, for ch5.

### DIFF
--- a/functional-programming-lean/src/monads.md
+++ b/functional-programming-lean/src/monads.md
@@ -209,7 +209,7 @@ In the case of `firstThirdFifthSeventh`, it is likely relevant for a user to kno
 
 像Lean这样的纯函数式语言并没有用于错误处理的内置异常机制，因为抛出或捕获异常超出了表达式逐步求值模型考虑的范围。
 然而函数式程序肯定需要处理错误。
-在`firstThirdFifthSeventh`的情况下，用户很可能需要知道列表有多长以及查找失败发生的位置。"
+在`firstThirdFifthSeventh`的情况下，用户很可能需要知道列表有多长以及查找失败发生的位置。
 
 <!--
 This is typically accomplished by defining a datatype that can be either an error or a result, and translating functions with exceptions into functions that return this datatype:
@@ -274,7 +274,7 @@ A single list lookup can conveniently return a value or an error:
 However, performing two list lookups requires handling potential failures:
 -->
 
-然而，连续的两个列表查找则需要处理可能发生的失败情况：
+然而，连续的两次列表查找则需要处理可能发生的失败情况：
 ```lean
 {{#example_decl Examples/Monads.lean firstThirdExcept}}
 ```

--- a/functional-programming-lean/src/monads/class.md
+++ b/functional-programming-lean/src/monads/class.md
@@ -217,9 +217,9 @@ Similarly, the type of `bind` should be `α → (α → Id β) → Id β`.
 Because this reduces to `α → (α → β) → β`, the second argument can be applied to the first to find the result.
 -->
 
-`pure`的类型应为`α → Id α`，但`Id α` **简化** 为 `α`。类似地，`bind`的类型应为`α → (α → Id β) → Id β`。
-由于这 **简化** 为 `α → (α → β) → β`，因此可以将第二个参数应用于第一个参数得到结果。
-*译者注：此处 **简化** 一词原文为reduces to，实际含义为beta-reduction，请见类型论相关资料。*
+`pure`的类型应为`α → Id α`，但`Id α` **归约** 为 `α`。类似地，`bind`的类型应为`α → (α → Id β) → Id β`。
+由于这 **归约** 为 `α → (α → β) → β`，因此可以将第二个参数应用于第一个参数得到结果。
+*译者注：此处 **归约** 一词原文为reduces to，实际含义为beta-reduction，请见类型论相关资料。*
 
 <!--
 With the identity monad, `mapM` becomes equivalent to `map`.


### PR DESCRIPTION
以下对应于commit中的三处修改：
1. 去掉多余的 "。
2. 建议将“个” 改为 “次”，这样可以避免歧义（两个_列表_查找）。
3. 是否应该按照习惯翻译为“归约”？