### PR TITLE
使引用本书其他章节的超链接能正常跳转到对应小节

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Setup mdBook
       uses: peaceiris/actions-mdbook@v1
       with:
-        mdbook-version: '0.4.17'
+        mdbook-version: '0.4.30'
 
     - name: Install mdbook-wordcount
       uses: baptiste0928/cargo-install@v1

--- a/functional-programming-lean/scripts/sync-title-id.py
+++ b/functional-programming-lean/scripts/sync-title-id.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+import sys
+import re
+from pathlib import Path
+from typing import Optional
+
+title_regex = re.compile(r"([^#]*)(#+) +(.*[^} ]) *(?:\{ *#([^} ]+) *\})? *")
+
+
+class Title:
+    def __init__(self, title: str, id: str, level: int, prefix: str):
+        self.title: str = title
+        self.id: str = id
+        self.level: int = level
+        self.prefix: str = prefix
+
+    @classmethod
+    def from_line(cls, line: str) -> "Title":
+        title_match = title_regex.fullmatch(line)
+        assert title_match is not None, "Unsupported title format: " + line
+        prefix, sharps, title, id = title_match.groups()
+        return cls(
+            title=title,
+            id=id or cls.title_to_default_id(title),
+            level=len(sharps),
+            prefix=prefix,
+        )
+
+    def to_line(self) -> str:
+        return f"{self.prefix}{'#'*self.level} {self.title} {{ #{self.id} }}"
+
+    def __repr__(self) -> str:
+        return f"Title(title = {self.title}, id = {self.id}, level = {self.level})"
+
+    @staticmethod
+    def title_to_default_id(title: str):
+        # https://github.com/rust-lang/mdBook/blob/94e0a44e152d8d7c62620e83e0632160977b1dd5/src/utils/mod.rs#L30-L43
+        return "".join(
+            "-" if c.isspace() else c
+            for c in title.lower()
+            if c.isalpha() or c.isspace() or c in ("_", "-")
+        )
+
+    @staticmethod
+    def is_title(title: str) -> bool:
+        if title.startswith("/- "):
+            title = title[len("/- ") :]
+        return title.startswith("#") and title.lstrip("#").startswith(" ")
+
+
+def sync_md_id(src_file: Path, dest_file: Path):
+    print(f"from {src_file} to {dest_file}:")
+    src_titles_reverse = [
+        Title.from_line(line.rstrip("\n"))
+        for line in open(src_file).readlines()[::-1]
+        if Title.is_title(line)
+    ]
+
+    dest_lines = [line.rstrip("\n") for line in open(dest_file).readlines()]
+    in_comment = False
+    for n in range(len(dest_lines)):
+        line = dest_lines[n]
+        if line.strip().startswith("<!--"):
+            in_comment = True
+            continue
+        if line.strip().startswith("-->"):
+            in_comment = False
+            continue
+        if in_comment:
+            continue
+        if not Title.is_title(line):
+            continue
+        title = Title.from_line(line)
+        assert (
+            len(src_titles_reverse) != 0
+        ), f"There are more titles in the destination, one of which is {title}"
+        src_title = src_titles_reverse.pop()
+        title.id = src_title.id
+        assert (
+            title.level == src_title.level
+        ), f"Titles from source and destination have different level: {src_title} {title}"
+        print(src_title, "->", title)
+        dest_lines[n] = title.to_line()
+
+    open(dest_file, "w").write("\n".join(dest_lines))
+
+    assert (
+        len(src_titles_reverse) == 0
+    ), f"There are more titles in the source, which are {src_titles_reverse[::-1]}"
+    print()
+
+
+def main(src: Path, dest: Path, suffix: Optional[str]):
+    if not src.is_dir():
+        sync_md_id(src, dest)
+        return
+    assert suffix is not None
+    for filename in Path(src).rglob("*." + suffix):
+        sync_md_id(filename, dest / filename.relative_to(src))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        usage = f"""Usage: {sys.argv[0]} upstream_directory translation_directory name_suffix
+   or: {sys.argv[0]} upstream_file translation_file
+Synchronize title IDs from upstream to translation, to make fragment identifier in urls work.
+
+Example: {sys.argv[0]} ./upstream/lean/ ./lean/ lean"""
+        print(usage, file=sys.stderr)
+        exit(1)
+    main(
+        Path(sys.argv[1]), Path(sys.argv[2]), None if len(sys.argv) < 4 else sys.argv[3]
+    )

--- a/functional-programming-lean/src/SUMMARY.md
+++ b/functional-programming-lean/src/SUMMARY.md
@@ -1,4 +1,4 @@
-# Lean 函数式编程
+# Lean 函数式编程 { #functional-programming-in-lean }
 
 [Lean 函数式编程](./title.md)
 [引言](./introduction.md)

--- a/functional-programming-lean/src/acknowledgments.md
+++ b/functional-programming-lean/src/acknowledgments.md
@@ -2,7 +2,7 @@
 # Acknowledgments
 -->
 
-# 鸣谢
+# 鸣谢 { #acknowledgments }
 
 <!--
 This free online book was made possible by the generous support of Microsoft Research, who paid for it to be written and given away.

--- a/functional-programming-lean/src/dependent-types.md
+++ b/functional-programming-lean/src/dependent-types.md
@@ -2,7 +2,7 @@
 # Programming with Dependent Types
 -->
 
-# 使用依值类型编程
+# 使用依值类型编程 { #programming-with-dependent-types }
 
 <!-- 
 In most statically-typed programming languages, there is a hermetic seal between the world of types and the world of programs.

--- a/functional-programming-lean/src/dependent-types/indexed-families.md
+++ b/functional-programming-lean/src/dependent-types/indexed-families.md
@@ -2,7 +2,7 @@
 # Indexed Families
 -->
 
-# 索引族
+# 索引族 { #indexed-families }
 
 <!--
 Polymorphic inductive types take type arguments.
@@ -344,7 +344,7 @@ The refinement of the length can be observed by making `n` into an explicit argu
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 Getting a feel for programming with dependent types requires experience, and the exercises in this section are very important.

--- a/functional-programming-lean/src/dependent-types/indices-parameters-universes.md
+++ b/functional-programming-lean/src/dependent-types/indices-parameters-universes.md
@@ -1,7 +1,7 @@
 <!--
 # Indices, Parameters, and Universe Levels
 -->
-# 索引、参量和宇宙层级
+# 索引、参量和宇宙层级 { #indices-parameters-and-universe-levels }
 
 <!--
 The distinction between indices and parameters of an inductive type is more than just a way to describe arguments to the type that either vary or do not between the constructors.

--- a/functional-programming-lean/src/dependent-types/pitfalls.md
+++ b/functional-programming-lean/src/dependent-types/pitfalls.md
@@ -2,7 +2,7 @@
 # Pitfalls of Programming with Dependent Types
 -->
 
-# 使用依值类型编程的陷阱
+# 使用依值类型编程的陷阱 { #pitfalls-of-programming-with-dependent-types }
 
 <!--
 The flexibility of dependent types allows more useful programs to be accepted by a type checker, because the language of types is expressive enough to describe variations that less-expressive type systems cannot.
@@ -104,7 +104,7 @@ Here, `n✝` represents the `Nat` that is one less than the argument `n`.
 ## Definitional Equality
 -->
 
-## 定义相等性
+## 定义相等性 { #definitional-equality }
 
 <!--
 In the definition of `plusL`, there is a pattern case `0, k => k`.
@@ -328,7 +328,7 @@ In particular, the fact that `plusL` is used in the type of `appendL` means that
 ## Getting Stuck on Addition
 -->
 
-## 在加法上卡住
+## 在加法上卡住 { #getting-stuck-on-addition }
 
 <!--
 What happens if append is defined with `plusR` instead?
@@ -403,7 +403,7 @@ Getting it unstuck requires [propositional equality](../type-classes/standard-cl
 ## Propositional Equality
 -->
 
-## 命题相等性
+## 命题相等性 { #propositional-equality }
 
 <!--
 Propositional equality is the mathematical statement that two expressions are equal.
@@ -630,7 +630,7 @@ However, Lean's type checker has enough information to fill them in automaticall
 ## Pros and Cons
 -->
 
-## 优势和劣势
+## 优势和劣势 { #pros-and-cons }
 
 <!--
 Indexed families have an important property: pattern matching on them affects definitional equality.
@@ -702,7 +702,7 @@ Fluency in their use is an important part of knowing when to use them.
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
  <!--
  * Using a recursive function in the style of `plusR_succ_left`, prove that for all `Nat`s `n` and `k`, `n.plusR k = n + k`.
@@ -715,4 +715,3 @@ Fluency in their use is an important part of knowing when to use them.
  -->
 
  * 写一个在 `Vect` 上的函数，其中 `plusR` 比 `plusL` 更自然：`plusL` 需要在定义中显示使用（命题相等性的）证明。
-

--- a/functional-programming-lean/src/dependent-types/summary.md
+++ b/functional-programming-lean/src/dependent-types/summary.md
@@ -2,13 +2,13 @@
 # Summary
 -->
 
-# 总结
+# 总结 { #summary }
 
 <!--
 ## Dependent Types
 -->
 
-## 依值类型
+## 依值类型 { #dependent-types }
 
 <!--
 Dependent types, where types contain non-type code such as function calls and ordinary data constructors, lead to a massive increase in the expressive power of a type system.
@@ -52,7 +52,7 @@ Type-level computation can be seen as a kind of partial evaluation, where only t
 ## The Universe Pattern
 -->
 
-# 宇宙设计模式
+## 宇宙设计模式 { #the-universe-pattern }
 
 <!--
 A common pattern when working with dependent types is to section off some subset of the type system.
@@ -87,7 +87,7 @@ Defining a custom universe has a number of advantages over using the types direc
 ## Indexed Families
 -->
 
-## 索引族
+## 索引族 { #indexed-families }
 
 <!--
 Datatypes can take two separate kinds of arguments: _parameters_ are identical in each constructor of the datatype, while _indices_ may vary between constructors.
@@ -137,7 +137,7 @@ Avoiding these slowdowns for complicated programs can require specialized techni
 ## Definitional and Propositional Equality
 -->
 
-## 定义相等性和命题相等性
+## 定义相等性和命题相等性 { #definitional-and-propositional-equality }
 
 <!--
 Lean's type checker must, from time to time, check whether two types should be considered interchangeable.

--- a/functional-programming-lean/src/dependent-types/typed-queries.md
+++ b/functional-programming-lean/src/dependent-types/typed-queries.md
@@ -2,7 +2,7 @@
 # Worked Example: Typed Queries
 -->
 
-# 实际案例：类型化查询
+# 实际案例：类型化查询 { #worked-example-typed-queries }
 
 <!--
 Indexed families are very useful when building an API that is supposed to resemble some other language.
@@ -28,7 +28,7 @@ However, it is large enough to demonstrate useful principles and techniques.
 ## A Universe of Data
 -->
 
-## 一个数据的宇宙
+## 一个数据的宇宙 { #a-universe-of-data }
 
 <!--
 In this relational algebra, the base data that can be held in columns can have types `Int`, `String`, and `Bool` and are described by the universe `DBType`:
@@ -128,7 +128,7 @@ Refining the type through dependent pattern matching allows the `reprPrec` metho
 ## Schemas and Tables
 -->
 
-## 数据库模式和表
+## 数据库模式和表 { #schemas-and-tables }
 
 <!--
 A schema describes the name and type of each column in a database:
@@ -205,7 +205,7 @@ Another example consists of waterfalls and a diary of visits to them:
 ### Recursion and Universes, Revisited
 -->
 
-### 回顾递归和宇宙
+### 回顾递归和宇宙 { #recursion-and-universes-revisited }
 
 <!--
 The convenient structuring of rows as tuples comes at a cost: the fact that `Row` treats its two base cases separately means that functions that use `Row` in their types and are defined recursively over the codes (that, is the schema) need to make the same distinctions.
@@ -252,7 +252,7 @@ A big part of the skill of programming with dependent types is the selection of 
 ### Column Pointers
 -->
 
-### 列指针
+### 列指针 { #column-pointers }
 
 <!--
 Some queries only make sense if a schema contains a particular column.
@@ -365,7 +365,7 @@ Programming with indexed families often requires the ability to switch fluently 
 ### Subschemas
 -->
 
-### 子数据库模式
+### 子数据库模式 { #subschemas }
 
 <!--
 One important operation in relational algebra is to _project_ a table or row into a smaller schema.
@@ -594,7 +594,7 @@ This relation is reflexive, meaning that every schema is a subschema of itself:
 ### Projecting Rows
 -->
 
-### 投影行
+### 投影行 { #projecting-rows }
 
 <!--
 Given evidence that `s'` is a subschema of `s`, a row in `s` can be projected into a row in `s'`.
@@ -622,7 +622,7 @@ It uses `Row.get` together with each `HasCol` in the `Subschema` argument to con
 ## Conditions and Selection
 -->
 
-## 条件和选取
+## 条件和选取 { #conditions-and-selection }
 
 <!--
 Projection removes unwanted columns from a table, but queries must also be able to remove unwanted rows.
@@ -757,7 +757,7 @@ Evaluating it for the highest peak in the US state of Idaho yields `false`, as I
 ## Queries
 -->
 
-## 查询
+## 查询 { #queries }
 
 <!--
 The query language is based on relational algebra.
@@ -834,7 +834,7 @@ TODO: coercion
 ## Executing Queries
 -->
 
-## 执行查询
+## 执行查询 { #executing-queries }
 
 <!--
 Executing queries requires a number of helper functions.
@@ -849,7 +849,7 @@ The result of a query is a table; this means that each operation in the query la
 ### Cartesian Product
 -->
 
-### 笛卡尔积
+### 笛卡尔积 { #cartesian-product }
 
 <!--
 Taking the Cartesian product of two tables is done by appending each row from the first table to each row from the second.
@@ -925,7 +925,7 @@ Just as with `List.product`, a loop with mutation in the identity monad can be u
 ### Difference
 -->
 
-### 差
+### 差 { #difference }
 
 <!--
 Removing undesired rows from a table can be done using `List.filter`, which takes a list and a function that returns a `Bool`.
@@ -973,7 +973,7 @@ This will be used with the `BEq` instance for `Row` when interpreting queries.
 ### Renaming Columns
 -->
 
-### 重命名
+### 重命名 { #renaming-columns }
 <!--
 Renaming a column in a row is done with a recursive function that traverses the row until the column in question is found, at which point the column with the new name gets the same value as the column with the old name:
 -->
@@ -1001,7 +1001,7 @@ It takes a very careful, often brittle, design to eliminate these kinds of "re-i
 ### Prefixing Column Names
 -->
 
-### 添加前缀
+### 添加前缀 { #prefixing-column-names }
 
 <!--
 Adding a prefix to column names is very similar to renaming a column.
@@ -1027,7 +1027,7 @@ Once again, this function only exists to change the type of a value.
 ### Putting the Pieces Together
 -->
 
-### 将所有东西组合在一起
+### 将所有东西组合在一起 { #putting-the-pieces-together }
 
 <!--
 With all of these helpers defined, executing a query requires only a short recursive function:
@@ -1125,7 +1125,7 @@ Because the example data includes only waterfalls in the USA, executing the quer
 ### Errors You May Meet
 -->
 
-### 可能遇到的错误
+### 可能遇到的错误 { #errors-you-may-meet }
 
 <!--
 Many potential errors are ruled out by the definition of `Query`.
@@ -1182,13 +1182,13 @@ Lean 的宏系统不仅可以为查询提供方便的语法，还可以生成的
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 ### Dates
 -->
 
-### 日期
+### 日期 { #dates }
 
 <!--
 Define a structure to represent dates. Add it to the `DBType` universe and update the rest of the code accordingly. Provide the extra `DBExpr` constructors that seem to be necessary.
@@ -1201,7 +1201,7 @@ Define a structure to represent dates. Add it to the `DBType` universe and updat
 ### Nullable Types
 -->
 
-### 可空类型
+### 可空类型 { #nullable-types }
 
 <!--
 Add support for nullable columns to the query language by representing database types with the following structure:
@@ -1231,7 +1231,7 @@ Use this type in place of `DBType` in `Column` and `DBExpr`, and look up SQL's r
 ### Experimenting with Tactics
 -->
 
-### 尝试策术
+### 尝试策术 { #experimenting-with-tactics }
 
 <!--
 What is the result of asking Lean to find values of the following types using `by repeat constructor`? Explain why each gives the result that it does.

--- a/functional-programming-lean/src/dependent-types/universe-pattern.md
+++ b/functional-programming-lean/src/dependent-types/universe-pattern.md
@@ -2,7 +2,7 @@
 # The Universe Design Pattern 
 -->
 
-# 宇宙设计模式
+# 宇宙设计模式 { #the-universe-design-pattern }
 
 <!--
 In Lean, types such as `Type`, `Type 3`, and `Prop` that classify other types are known as universes.
@@ -111,7 +111,7 @@ The `t` in the error message stands for an unknown value of type `NestedPairs`.
 ## Type Classes vs Universes 
 -->
 
-## 类型类 vs 宇宙
+## 类型类 vs 宇宙 { #type-classes-vs-universes }
 
 <!--
 Type classes allow an open-ended collection of types to be used with an API as long as they have implementations of the necessary interfaces.
@@ -147,7 +147,7 @@ Type classes are useful in many of the same situations as interfaces in Java or 
 ## A Universe of Finite Types 
 -->
 
-## 一个有限类型的宇宙
+## 一个有限类型的宇宙 { #a-universe-of-finite-types }
 
 <!--
 Restricting the types that can be used with an API to a predetermined collection can enable operations that would be impossible for an open-ended API.
@@ -463,7 +463,7 @@ Nested exponentials grow quickly, and there are many higher-order functions.
 ## Exercises 
 -->
 
-## 练习
+## 练习 { #exercises }
 
  <!--
  * Write a function that converts any value from a type coded for by `Finite` into a string. Functions should be represented as their tables.

--- a/functional-programming-lean/src/functor-applicative-monad.md
+++ b/functional-programming-lean/src/functor-applicative-monad.md
@@ -2,7 +2,7 @@
 # Functors, Applicative Functors, and Monads
 -->
 
-# 函子、应用函子与单子
+# 函子、应用函子与单子 { #functors-applicative-functors-and-monads }
 
 <!--
 `Functor` and `Monad` both describe operations for types that are still waiting for a type argument.

--- a/functional-programming-lean/src/functor-applicative-monad/alternative.md
+++ b/functional-programming-lean/src/functor-applicative-monad/alternative.md
@@ -2,13 +2,13 @@
 # Alternatives
 -->
 
-# 选择子
+# 选择子 { #alternatives }
 
 <!--
 ## Recovery from Failure
 -->
 
-## 从失败中恢复
+## 从失败中恢复 { #recovery-from-failure }
 
 <!--
 `Validate` can also be used in situations where there is more than one way for input to be acceptable.
@@ -279,7 +279,7 @@ The worst possible input returns all the possible failures:
 ## The `Alternative` Class
 -->
 
-## `Alternative` 类
+## `Alternative` 类 { #the-alternative-class }
 
 <!--
 Many types support a notion of failure and recovery.
@@ -373,13 +373,13 @@ Running it on `20` yields the expected results:
 ## Exercises
 -->
 
-## 练习题
+## 练习题 { #exercises }
 
 <!--
 ### Improve Validation Friendliness
 -->
 
-### 提高验证的友好性
+### 提高验证的友好性 { #improve-validation-friendliness }
 
 <!--
 The errors returned from `Validate` programs that use `<|>` can be difficult to read, because inclusion in the list of errors simply means that the error can be reached through _some_ code path.

--- a/functional-programming-lean/src/functor-applicative-monad/applicative-contract.md
+++ b/functional-programming-lean/src/functor-applicative-monad/applicative-contract.md
@@ -2,7 +2,7 @@
 # The Applicative Contract
 -->
 
-# 应用函子的契约
+# 应用函子的契约 { #the-applicative-contract }
 
 <!--
 Just like `Functor`, `Monad`, and types that implement `BEq` and `Hashable`, `Applicative` has a set of rules that all instances should adhere to.
@@ -85,7 +85,7 @@ In the fourth case, assume that `u` is `some f`, because if it's `none`, both si
 ## All Applicatives are Functors
 -->
 
-## 所有的应用函子都是函子
+## 所有的应用函子都是函子 { #all-applicatives-are-functors }
 
 
 <!--
@@ -133,7 +133,7 @@ This justifies a definition of `Applicative` that extends `Functor`, with a defa
 ## All Monads are Applicative Functors
 -->
 
-## 所有单子都是应用函子
+## 所有单子都是应用函子 { #all-monads-are-applicative-functors }
 
 <!--
 An instance of `Monad` already requires an implementation of `pure`.
@@ -244,7 +244,7 @@ This justifies a definition of `Monad` that extends `Applicative`, with a defaul
 ## Additional Stipulations
 -->
 
-## 附加规定
+## 附加规定 { #additional-stipulations }
 
 <!--
 In addition to adhering to the individual contracts associated with each type class, combined implementations `Functor`, `Applicative` and `Monad` should work equivalently to these default implementations.

--- a/functional-programming-lean/src/functor-applicative-monad/applicative.md
+++ b/functional-programming-lean/src/functor-applicative-monad/applicative.md
@@ -2,7 +2,7 @@
 # Applicative Functors
 -->
 
-# 应用函子
+# 应用函子 { #applicative-functors }
 
 <!--
 An _applicative functor_ is a functor that has two additional operations available: `pure` and `seq`.
@@ -197,7 +197,7 @@ After all, a caller could choose `α` to be `Empty`, which has no values at all.
 ## A Non-Monadic Applicative
 -->
 
-## 一个非单子的应用函子
+## 一个非单子的应用函子 { #a-non-monadic-applicative }
 
 <!--
 When validating user input to a form, it's generally considered to be best to provide many errors at once, rather than one error at a time.
@@ -244,7 +244,7 @@ Unlike `Except`, it allows multiple errors to be accumulated, without a risk of 
 ### User Input
 -->
 
-### 用户输入
+### 用户输入 { #user-input }
 
 <!--
 As an example of user input, take the following structure:
@@ -279,7 +279,7 @@ With this tool in hand, a validation framework can be written that uses an appli
 ### Subtypes
 -->
 
-### 子类型
+### 子类型 { #subtypes }
 
 <!--
 Representing these conditions is easiest with one additional Lean type, called `Subtype`:
@@ -387,7 +387,7 @@ In the `then` branch, `h` is bound to evidence that `n > 0`, and this evidence c
 ### Validated Input
 -->
 
-### 经验证输入
+### 经验证输入 { #validated-input }
 
 <!--
 The validated user input is a structure that expresses the business logic using multiple techniques:

--- a/functional-programming-lean/src/functor-applicative-monad/complete.md
+++ b/functional-programming-lean/src/functor-applicative-monad/complete.md
@@ -2,7 +2,7 @@
 # The Complete Definitions
 -->
 
-# 完整定义
+# 完整定义 { #the-complete-definitions }
 
 <!--
 Now that all the relevant language features have been presented, this section describes the complete, honest definitions of `Functor`, `Applicative`, and `Monad` as they occur in the Lean standard library.
@@ -16,7 +16,7 @@ For the sake of understanding, no details are omitted.
 ## Functor
 -->
 
-## 函子
+## 函子 { #functor }
 
 <!--
 The complete definition of the `Functor` class makes use of universe polymorphism and a default method implementation:
@@ -106,7 +106,7 @@ All the type classes in this section share this property.
 ## Applicative
 -->
 
-## 应用类型类
+## 应用类型类 { #applicative }
 
 <!--
 The `Applicative` type class is actually built from a number of smaller classes that each contain some of the relevant methods.
@@ -254,7 +254,7 @@ From the perspective of effects, the side effects of `a` occur, but the values a
 ## Monad
 -->
 
-## 单子
+## 单子 { #monad }
 
 <!--
 Just as the constituent operations of `Applicative` are split into their own type classes, `Bind` has its own class as well:
@@ -286,7 +286,7 @@ From the perspective of API boundaries, any type with a `Monad` instance gets in
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
  1. Understand the default implementations of `map`, `seq`, `seqLeft`, and `seqRight` in `Monad` by working through examples such as `Option` and `Except`. In other words, substitute their definitions for `bind` and `pure` into the default definitions, and simplify them to recover the versions `map`, `seq`, `seqLeft`, and `seqRight` that would be written by hand.

--- a/functional-programming-lean/src/functor-applicative-monad/inheritance.md
+++ b/functional-programming-lean/src/functor-applicative-monad/inheritance.md
@@ -2,7 +2,7 @@
 # Structures and Inheritance
 -->
 
-# 结构体和继承
+# 结构体和继承 { #structures-and-inheritance }
 
 <!--
 In order to understand the full definitions of `Functor`, `Applicative`, and `Monad`, another Lean feature is necessary: structure inheritance.
@@ -198,7 +198,7 @@ Evaluating `{{#example_in Examples/FunctorApplicativeMonad.lean smallTroll}}` yi
 ### Multiple Inheritance
 -->
 
-### 多重继承
+### 多重继承 { #multiple-inheritance }
 
 <!--
 A helper is a mythical creature that can provide assistance when given the correct payment:
@@ -299,7 +299,7 @@ The `@[reducible]` attribute has the same effect as writing `abbrev`.
 ### Default Declarations
 -->
 
-### 默认声明
+### 默认声明 { #default-declarations }
 
 <!--
 When one structure inherits from another, default field definitions can be used to instantiate the parent structure's fields based on the child structure's fields.
@@ -371,7 +371,7 @@ The two sized fields on `huldre` match one another:
 ### Type Class Inheritance
 -->
 
-### 类型类继承
+### 类型类继承 { #type-class-inheritance }
 
 <!--
 Behind the scenes, type classes are structures.

--- a/functional-programming-lean/src/functor-applicative-monad/summary.md
+++ b/functional-programming-lean/src/functor-applicative-monad/summary.md
@@ -2,13 +2,13 @@
 # Summary
 -->
 
-# 总结
+# 总结 { #summary }
 
 <!--
 ## Type Classes and Structures
 -->
 
-## 类型类与结构体
+## 类型类与结构体 { #type-classes-and-structures }
 
 <!--
 Behind the scenes, type classes are represented by structures.
@@ -28,7 +28,7 @@ Both structures and classes may provide default values for fields (which are def
 ## Structures and Inheritance
 -->
 
-## 结构体和继承
+## 结构体和继承 { #structures-and-inheritance }
 
 <!--
 Structures may inherit from other structures.
@@ -56,7 +56,7 @@ Together with default methods, this can be used to create a fine-grained hierarc
 ## Applicative Functors
 -->
 
-## 应用函子
+## 应用函子 { #applicative-functors }
 
 <!--
 An applicative functor is a functor with two additional operations:
@@ -106,7 +106,7 @@ The default implementations of `Functor`'s methods in terms of `Applicative`'s, 
 ## Universes
 -->
 
-## 宇宙
+## 宇宙 { #universes }
 
 <!--
 To allow Lean to be used as both a programming language and a theorem prover, some restrictions on the language are necessary.

--- a/functional-programming-lean/src/functor-applicative-monad/universes.md
+++ b/functional-programming-lean/src/functor-applicative-monad/universes.md
@@ -2,7 +2,7 @@
 # Universes
 -->
 
-# 宇宙
+# 宇宙 { #universes }
 
 <!--
 In the interests of simplicity, this book has thus far papered over an important feature of Lean: _universes_.
@@ -142,7 +142,7 @@ Similarly, even though `Type` is in `Type 1`, the function type `{{#example_in E
 ## User Defined Types
 -->
 
-## 用户定义类型
+## 用户定义类型 { #user-defined-types }
 
 <!--
 Structures and inductive datatypes can be declared to inhabit particular universes.
@@ -212,7 +212,7 @@ Then, if Lean rejects the definition, increase its level by one, which will usua
 ## Universe Polymorphism
 -->
 
-## 宇宙多态
+## 宇宙多态 { #universe-polymorphism }
 
 <!--
 Defining a datatype in a specific universe can lead to code duplication.
@@ -372,7 +372,7 @@ In positions where Lean expects a universe level, any of the following are allow
 ### Writing Universe-Polymorphic Definitions
 -->
 
-### 编写宇宙多态定义
+### 编写宇宙多态定义 { #writing-universe-polymorphic-definitions }
 
 <!--
 Until now, every datatype defined in this book has been in `Type`, the smallest universe of data.
@@ -404,7 +404,7 @@ Non-polymorphic types, such as `Nat` and `String`, can be placed directly in `Ty
 ### `Prop` and Polymorphism
 -->
 
-### `Prop` 和多态
+### `Prop` 和多态 { #prop-and-polymorphism }
 
 <!--
 Just as `Type`, `Type 1`, and so on describe types that classify programs and data, `Prop` classifies logical propositions.
@@ -466,7 +466,7 @@ Together with `Sort`, this allows the special rule for functions that return `Pr
 ## Polymorphism in Practice
 -->
 
-## 多态的实际应用
+## 多态的实际应用 { #polymorphism-in-practice }
 
 <!--
 In the remainder of the book, definitions of polymorphic datatypes, structures, and classes will use universe polymorphism in order to be consistent with the Lean standard library.

--- a/functional-programming-lean/src/getting-to-know.md
+++ b/functional-programming-lean/src/getting-to-know.md
@@ -6,8 +6,6 @@ installed correctly and that the programmer is able to run the
 compiled code.
 -->
 
-# 了解 Lean
-
 按照惯例，介绍一门编程语言通常会编译并运行一个在控制台上显示「Hello, world!」
 的程序。这个简单的程序能确保语言工具安装正确，且程序员能够运行已编译的代码。
 

--- a/functional-programming-lean/src/getting-to-know/conveniences.md
+++ b/functional-programming-lean/src/getting-to-know/conveniences.md
@@ -2,7 +2,7 @@
 # Additional Conveniences
 -->
 
-# 其他便利功能
+# 其他便利功能 { #additional-conveniences }
 
 <!--
 Lean contains a number of convenience features that make programs much more concise.
@@ -14,7 +14,7 @@ Lean 包含许多便利功能，能够让程序更加简洁。
 ## Automatic Implicit Arguments
 -->
 
-## 自动隐式参数
+## 自动隐式参数 { #automatic-implicit-arguments }
 
 <!--
 When writing polymorphic functions in Lean, it is typically not necessary to list all the implicit arguments.
@@ -50,7 +50,7 @@ This can greatly simplify highly polymorphic definitions that take many implicit
 ## Pattern-Matching Definitions
 -->
 
-## 模式匹配定义
+## 模式匹配定义 { #pattern-matching-definitions }
 
 <!--
 When defining functions with `def`, it is quite common to name an argument and then immediately use it with pattern matching.
@@ -126,7 +126,7 @@ This function is called `Option.getD` in the standard library, and can be called
 ## Local Definitions
 -->
 
-## 局部定义
+## 局部定义 { #local-definitions }
 
 <!--
 It is often useful to name intermediate steps in a computation.
@@ -233,7 +233,7 @@ When it reaches the end of the input list, `soFar` contains a reversed version o
 ## Type Inference
 -->
 
-## 类型推断
+## 类型推断 { #type-inference }
 
 <!--
 In many situations, Lean can automatically determine an expression's type.
@@ -390,7 +390,7 @@ Especially while still learning Lean, it is useful to provide most types explici
 ## Simultaneous Matching
 -->
 
-## 同时匹配
+## 同时匹配 { #simultaneous-matching }
 
 <!--
 Pattern-matching expressions, just like pattern-matching definitions, can match on multiple values at once.
@@ -410,7 +410,7 @@ Here is a version of `drop` that uses simultaneous matching:
 ## Natural Number Patterns
 -->
 
-## 自然数模式
+## 自然数模式 { #natural-number-patterns }
 
 <!--
 In the section on [datatypes and patterns](datatypes-and-patterns.md), `even` was defined like this:
@@ -492,7 +492,7 @@ This restriction enables Lean to transform all uses of the `+` notation in a pat
 ## Anonymous Functions
 -->
 
-## 匿名函数
+## 匿名函数 { #anonymous-functions }
 
 <!--
 Functions in Lean need not be defined at the top level.
@@ -640,7 +640,7 @@ while `{{#example_in Examples/Intro.lean applyCdot}}` results in:
 ## Namespaces
 -->
 
-## 命名空间
+## 命名空间 { #namespaces }
 
 <!--
 Each name in Lean occurs in a _namespace_, which is a collection of names.
@@ -762,7 +762,7 @@ To do this, simply omit the `in` from a top-level usage of `open`.
 ## if let
 -->
 
-## if let
+## if let { #if-let }
 
 <!--
 When consuming values that have a sum type, it is often the case that only a single constructor is of interest.
@@ -810,7 +810,7 @@ In some contexts, using `if let` instead of `match` can make code easier to read
 ## Positional Structure Arguments
 -->
 
-## 带位置的结构体参数
+## 带位置的结构体参数 { #positional-structure-arguments }
 
 <!--
 The [section on structures](structures.md) presents two ways of constructing structures:
@@ -870,7 +870,7 @@ Adding an annotation, such as in `{{#example_in Examples/Intro.lean pointPosWith
 ## String Interpolation
 -->
 
-## 字符串插值
+## 字符串插值 { #string-interpolation }
 
 <!--
 In Lean, prefixing a string with `s!` triggers _interpolation_, where expressions contained in curly braces inside the string are replaced with their values.

--- a/functional-programming-lean/src/getting-to-know/datatypes-and-patterns.md
+++ b/functional-programming-lean/src/getting-to-know/datatypes-and-patterns.md
@@ -2,7 +2,7 @@
 # Datatypes and Patterns
 -->
 
-# 数据类型与模式匹配
+# 数据类型与模式匹配 { #datatypes-and-patterns }
 
 <!--
 Structures enable multiple independent pieces of data to be combined into a coherent whole that is represented by a brand new type.
@@ -189,7 +189,7 @@ It also illustrates that Lean constructors correspond to objects in JavaScript o
 ## Pattern Matching
 -->
 
-## 模式匹配
+## 模式匹配 { #pattern-matching }
 
 <!--
 In many languages, these kinds of data are consumed by first using an instance-of operator to check which subclass has been received and then reading the values of the fields that are available in the given subclass.
@@ -340,7 +340,7 @@ In this case, it would have been much simpler to just use the `z` accessor, but 
 ## Recursive Functions
 -->
 
-## 递归函数
+## 递归函数 { #recursive-functions }
 
 <!--
 Definitions that refer to the name being defined are called _recursive definitions_.
@@ -486,5 +486,5 @@ This topic is explored in [the final chapter](../programs-proofs/inequalities.md
 -->
 
 此消息表示 `div` 需要手动证明停机。这个主题在
-[最后一章](../programs-proofs/inequalities.md#用减法迭代表示除法)
+[最后一章](../programs-proofs/inequalities.md#division-as-iterated-subtraction)
 中进行了探讨。

--- a/functional-programming-lean/src/getting-to-know/evaluating.md
+++ b/functional-programming-lean/src/getting-to-know/evaluating.md
@@ -2,7 +2,7 @@
 # Evaluating Expressions
 -->
 
-# 求值表达式
+# 求值表达式 { #evaluating-expressions }
 
 <!--
 The most important thing to understand as a programmer learning Lean
@@ -222,7 +222,7 @@ For the sake of brevity, a series of evaluation steps like this will sometimes b
 ## Messages You May Meet
 -->
 
-## 可能会遇到的信息
+## 可能会遇到的信息 { #messages-you-may-meet }
 
 <!--
 Asking Lean to evaluate a function application that is missing an argument will lead to an error message.
@@ -268,7 +268,7 @@ Lean 无法向用户显示函数，因此在被要求这样做时会返回错误
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 What are the values of the following expressions? Work them out by hand,

--- a/functional-programming-lean/src/getting-to-know/functions-and-definitions.md
+++ b/functional-programming-lean/src/getting-to-know/functions-and-definitions.md
@@ -2,7 +2,7 @@
 # Functions and Definitions
 -->
 
-# 函数与定义
+# 函数与定义 { #functions-and-definitions }
 
 <!--
 In Lean, definitions are introduced using the `def` keyword. For instance, to define the name `{{#example_in Examples/Intro.lean helloNameVal}}` to refer to the string `{{#example_out Examples/Intro.lean helloNameVal}}`, write:
@@ -82,7 +82,7 @@ Nonetheless, definitions such as `hello` introduce names that refer _directly_ t
 ## Defining Functions
 -->
 
-## 定义函数
+## 定义函数 { #defining-functions }
 
 <!--
 There are a variety of ways to define functions in Lean. The simplest is to place the function's arguments before the definition's type, separated by spaces. For instance, a function that adds one to its argument can be written:
@@ -180,7 +180,7 @@ Function arrows associate to the right, which means that `Nat → Nat → Nat` s
 ### Exercises
 -->
 
-### 练习
+### 练习 { #exercises }
 
 <!--
  * Define the function `joinStringsWith` with type `String -> String -> String -> String` that creates a new string by placing its first argument between its second and third arguments. `{{#example_eval Examples/Intro.lean joinStringsWithEx 0}}` should evaluate to `{{#example_eval Examples/Intro.lean joinStringsWithEx 1}}`.
@@ -200,7 +200,7 @@ Function arrows associate to the right, which means that `Nat → Nat → Nat` s
 ## Defining Types
 -->
 
-## 定义类型
+## 定义类型 { #defining-types }
 
 <!--
 Most typed programming languages have some means of defining aliases for types, such as C's `typedef`.
@@ -246,7 +246,7 @@ Because ``Str`` has been defined to mean ``String``, the definition of ``aStr`` 
 ### Messages You May Meet
 -->
 
-### 你可能会遇到的信息
+### 你可能会遇到的信息 { #messages-you-may-meet }
 
 <!--
 Experimenting with using definitions for types is made more complicated by the way that Lean supports overloaded integer literals.

--- a/functional-programming-lean/src/getting-to-know/polymorphism.md
+++ b/functional-programming-lean/src/getting-to-know/polymorphism.md
@@ -2,7 +2,7 @@
 # Polymorphism
 -->
 
-# 多态
+# 多态 { #polymorphism }
 
 <!--
 Just as in most languages, types in Lean can take arguments.
@@ -215,7 +215,7 @@ Evaluation can occur both in the expression and its type:
 ## Linked Lists
 -->
 
-## 链表
+## 链表 { #linked-lists }
 
 <!--
 Lean's standard library includes a canonical linked list datatype, called `List`, and special syntax that makes it more convenient to use.
@@ -329,7 +329,7 @@ To make it easier to read functions on lists, the bracket notation `[]` can be u
 ## Implicit Arguments
 -->
 
-## 隐式参数
+## 隐式参数 { #implicit-arguments }
 
 <!--
 Both `replaceX` and `length` are somewhat bureaucratic to use, because the type argument is typically uniquely determined by the later values.
@@ -423,7 +423,7 @@ For instance, a version of `List.length` that only works for lists of integers c
 ## More Built-In Datatypes
 -->
 
-## 更多内置数据类型
+## 更多内置数据类型 { #more-built-in-datatypes }
 
 <!--
 In addition to lists, Lean's standard library contains a number of other structures and inductive datatypes that can be used in a variety of contexts.
@@ -435,7 +435,7 @@ In addition to lists, Lean's standard library contains a number of other structu
 ### `Option`
 -->
 
-### `Option` 可选类型
+### `Option` 可选类型 { #option }
 
 <!--
 Not every list has a first entry—some lists are empty.
@@ -601,7 +601,7 @@ Both messages use the _same_ metavariable to describe the missing implicit argum
 ### `Prod`
 -->
 
-### `Prod` 积类型
+### `Prod` 积类型 { #prod }
 
 <!--
 The `Prod` structure, short for "Product", is a generic way of joining two values together.
@@ -688,7 +688,7 @@ In other words, all products of more than two types, and their corresponding con
 ### `Sum`
 -->
 
-### `Sum` 和类型
+### `Sum` 和类型 { #sum }
 
 <!--
 The `Sum` datatype is a generic way of allowing a choice between values of two different types.
@@ -770,7 +770,7 @@ As expected, `{{#example_in Examples/Intro.lean dogCount}}` yields `{{#example_o
 ### `Unit`
 -->
 
-### `Unit` 单位类型
+### `Unit` 单位类型 { #unit }
 
 <!--
 `Unit` is a type with just one argumentless constructor, called `unit`.
@@ -827,7 +827,7 @@ Unit's constructor can be written as empty parentheses: `{{#example_in Examples/
 ### `Empty`
 -->
 
-### `Empty` 空类型
+### `Empty` 空类型 { #empty }
 
 <!--
 The `Empty` datatype has no constructors whatsoever.
@@ -855,7 +855,7 @@ This can allow generic code to be used in contexts that have additional restrict
 ### Naming: Sums, Products, and Units
 -->
 
-### 命名：和类型，积类型与单位类型
+### 命名：和类型，积类型与单位类型 { #naming-sums-products-and-units }
 
 <!--
 Generally speaking, types that offer multiple constructors are called _sum types_, while types whose single constructor takes multiple arguments are called _product types_.
@@ -881,7 +881,7 @@ Similarly, \\( 2 \times 1 = 2 \\), and \\( 2 + 1 = 3 \\).
 ## Messages You May Meet
 -->
 
-## 你可能会遇到的信息
+## 你可能会遇到的信息 { #messages-you-may-meet }
 
 <!--
 Not all definable structures or inductive types can have the type `Type`.
@@ -989,7 +989,7 @@ The same message can appear when type arguments are omitted in other contexts, s
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
  * Write a function to find the last entry in a list. It should return an `Option`.

--- a/functional-programming-lean/src/getting-to-know/structures.md
+++ b/functional-programming-lean/src/getting-to-know/structures.md
@@ -2,7 +2,7 @@
 # Structures
 -->
 
-# 结构体
+# 结构体 { #structures }
 
 <!--
 The first step in writing a program is usually to identify the problem domain's concepts, and then find suitable representations for them in code.
@@ -282,7 +282,7 @@ To make programs more concise, Lean also allows the structure type annotation in
 ## Updating Structures
 -->
 
-## 更新结构体
+## 更新结构体 { #updating-structures }
 
 <!--
 Imagine a function `zeroX` that replaces the `x` field of a `Point` with `0.0`.
@@ -383,7 +383,7 @@ All references to the old structure continue to refer to the same field values i
 ## Behind the Scenes
 -->
 
-## 幕后
+## 幕后 { #behind-the-scenes }
 
 <!--
 Every structure has a _constructor_.
@@ -559,7 +559,7 @@ This is because the target of the accessor notation is used as the first argumen
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
  * Define a structure named `RectangularPrism` that contains the height, width, and depth of a rectangular prism, each as a `Float`.

--- a/functional-programming-lean/src/getting-to-know/summary.md
+++ b/functional-programming-lean/src/getting-to-know/summary.md
@@ -2,13 +2,13 @@
 # Summary
 -->
 
-# 总结
+# 总结 { #summary }
 
 <!--
 ## Evaluating Expressions
 -->
 
-## 求值表达式
+## 求值表达式 { #evaluating-expressions }
 
 <!--
 In Lean, computation occurs when expressions are evaluated.
@@ -34,7 +34,7 @@ Lean 变量只是值的占位符，而非可以写入新值的位置。变量的
 ## Functions
 -->
 
-## 函数
+## 函数 { #functions }
 
 <!--
 Functions in Lean are first-class values, meaning that they can be passed as arguments to other functions, saved in variables, and used like any other value.
@@ -74,7 +74,7 @@ There are three primary ways of creating functions:
 ## Types
 -->
 
-## 类型
+## 类型 { #types }
 
 <!--
 Lean checks that every expression has a type.
@@ -134,7 +134,7 @@ Giving an argument a name in a function type allows later types to mention that 
 ## Structures and Inductive Types
 -->
 
-## 结构体与归纳类型
+## 结构体与归纳类型 { #structures-and-inductive-types }
 
 <!--
 Brand new datatypes can be introduced to Lean using the `structure` or `inductive` features.
@@ -167,7 +167,7 @@ Pattern matching means that knowing how to create a value implies knowing how to
 ## Recursion
 -->
 
-## 递归
+## 递归 { #recursion }
 
 <!--
 A definition is recursive when the name being defined is used in the definition itself.

--- a/functional-programming-lean/src/getting-to-know/types.md
+++ b/functional-programming-lean/src/getting-to-know/types.md
@@ -2,7 +2,7 @@
 # Types
 -->
 
-# 类型
+# 类型 { #types }
 
 <!--
 Types classify programs based on the values that they can

--- a/functional-programming-lean/src/hello-world.md
+++ b/functional-programming-lean/src/hello-world.md
@@ -1,4 +1,4 @@
-# Hello, World!
+# Hello, World! { #hello-world }
 
 <!--
 While Lean has been designed to have a rich interactive environment in which programmers can get quite a lot of feedback from the language without leaving the confines of their favorite text editor, it is also a language in which real programs can be written.

--- a/functional-programming-lean/src/hello-world/cat.md
+++ b/functional-programming-lean/src/hello-world/cat.md
@@ -2,7 +2,7 @@
 # Worked Example: `cat`
 -->
 
-# 现实示例 `cat`
+# 现实示例 `cat` { #worked-example-cat }
 
 <!--
 The standard Unix utility `cat` takes a number of command-line options, followed by zero or more input files.
@@ -40,7 +40,7 @@ This makes it easier to learn the mechanical process of typing in code, recoveri
 ## Getting started
 -->
 
-## 开始
+## 开始 { #getting-started }
 
 <!--
 The first step in implementing `feline` is to create a package and decide how to organize the code.
@@ -84,7 +84,7 @@ Ensure that the code can be built by running `{{#command {feline/1} {feline/1} {
 ## Concatenating Streams
 -->
 
-## 连接流
+## 连接流 { #concatenating-streams }
 
 <!--
 Now that the basic skeleton of the program has been built, it's time to actually enter the code.
@@ -115,7 +115,7 @@ For the sake of simplicity, this implementation uses a conservative 20 kilobyte 
 ### Streams
 -->
 
-### 流
+### 流 { #streams }
 
 <!--
 The main work of `feline` is done by `dump`, which reads input one block at a time, dumping the result to standard output, until the end of the input has been reached:
@@ -229,7 +229,7 @@ Lean 文件勾柄跟踪了一个底层文件的描述符。当没有对文件勾
 ### Handling Input
 -->
 
-### 处理输入
+### 处理输入 { #handling-input }
 
 <!--
 The main loop of `feline` is another tail-recursive function, called `process`.
@@ -283,7 +283,7 @@ Thus, `process` does not introduce any non-termination.
 ### Main
 -->
 
-### Main 活动
+### Main 活动 { #main }
 
 <!--
 The final step is to write the `main` action.
@@ -319,7 +319,7 @@ Otherwise, the arguments should be processed one after the other.
 ## Meow!
 -->
 
-## 喵！
+## 喵！ { #meow }
 
 <!--
 To check whether `feline` works, the first step is to build it with `{{#command {feline/2} {feline/2} {lake build} }}`.
@@ -405,7 +405,7 @@ should yield
 ## Exercise
 -->
 
-## 练习
+## 练习 { #exercise }
 
 <!--
 Extend `feline` with support for usage information.

--- a/functional-programming-lean/src/hello-world/conveniences.md
+++ b/functional-programming-lean/src/hello-world/conveniences.md
@@ -2,13 +2,13 @@
 # Additional Conveniences
 -->
 
-# 其他便利功能
+# 其他便利功能 { #additional-conveniences }
 
 <!--
 ## Nested Actions
 -->
 
-## 嵌套活动
+## 嵌套活动 { #nested-actions }
 
 <!--
 Many of the functions in `feline` exhibit a repetitive pattern in which an `IO` action's result is given a name, and then used immediately and only once.
@@ -153,7 +153,7 @@ Indeed, they could not be wrapped this way, because the type of the conditional 
 ## Flexible Layouts for `do`
 -->
 
-## `do` 的灵活布局
+## `do` 的灵活布局 { #flexible-layouts-for-do }
 
 <!--
 In Lean, `do` expressions are whitespace-sensitive.
@@ -192,7 +192,7 @@ Idiomatic Lean code uses curly braces with `do` very rarely.
 ## Running `IO` Actions With `#eval`
 -->
 
-## 用 `#eval` 运行 `IO` 活动
+## 用 `#eval` 运行 `IO` 活动 { #running-io-actions-with-eval }
 
 <!--
 Lean's `#eval` command can be used to execute `IO` actions, rather than just evaluating them.

--- a/functional-programming-lean/src/hello-world/running-a-program.md
+++ b/functional-programming-lean/src/hello-world/running-a-program.md
@@ -2,7 +2,7 @@
 # Running a Program
 -->
 
-# 运行程序
+# 运行程序 { #running-a-program }
 
 <!--
 The simplest way to run a Lean program is to use the `--run` option to the Lean executable.
@@ -36,7 +36,7 @@ The program displays `{{#command_out {hello} {lean --run Hello.lean} }}` and exi
 ## Anatomy of a Greeting
 -->
 
-## 问候程序的剖析
+## 问候程序的剖析 { #anatomy-of-a-greeting }
 
 <!--
 When Lean is invoked with the `--run` option, it invokes the program's `main` definition.
@@ -87,7 +87,7 @@ Lean 区分表达式的 **求值（Evaluation）**（严格遵循用变量值替
 ## Functional Programming vs Effects
 -->
 
-## 函数式编程与副作用
+## 函数式编程与副作用 { #functional-programming-vs-effects }
 
 <!--
 Lean's model of computation is based on the evaluation of mathematical expressions, in which variables are given exactly one value that does not change over time.
@@ -167,7 +167,7 @@ RTS 执行这些活动，委托给用户的 Lean 代码来执行计算。从 Lea
 ## Real-World Functional Programming
 -->
 
-## 现实世界的函数式编程
+## 现实世界的函数式编程 { #real-world-functional-programming }
 
 <!--
 The other useful way to think about side effects in Lean is by considering `IO` actions to be functions that take the entire world as an argument and return a value paired with a new world.
@@ -217,7 +217,7 @@ To enable programs to use multiple effects, there is a sub-language of Lean call
 ## Combining `IO` Actions
 -->
 
-## 组合 `IO` 活动
+## 组合 `IO` 活动 { #combining-io-actions }
 
 <!--
 Most useful programs accept input in addition to producing output.
@@ -349,5 +349,5 @@ Finally, the last line in the program is:
 It uses [string interpolation](../getting-to-know/conveniences.md#string-interpolation) to insert the provided name into a greeting string, writing the result to `stdout`.
 -->
 
-它使用[字符串插值](../getting-to-know/conveniences.md#字符串插值)
+它使用[字符串插值](../getting-to-know/conveniences.md#string-interpolation)
 将提供的名称插入到问候字符串中，并将结果写入到 `stdout`。

--- a/functional-programming-lean/src/hello-world/starting-a-project.md
+++ b/functional-programming-lean/src/hello-world/starting-a-project.md
@@ -2,7 +2,7 @@
 # Starting a Project
 -->
 
-# 创建项目
+# 创建项目 { #starting-a-project }
 
 <!--
 As a program written in Lean becomes more serious, an ahead-of-time compiler-based workflow that results in an executable becomes more attractive.
@@ -30,7 +30,7 @@ Lake 也包含一门用于配置构建的特殊语言。
 ## First steps
 -->
 
-## 入门
+## 入门 { #first-steps }
 
 <!--
 To get started with a project that uses Lake, use the command `{{#command {first-lake} {lake} {lake new greeting} }}` in a directory that does not already contain a file or directory called `greeting`.
@@ -127,7 +127,7 @@ Running `{{#command {first-lake/greeting} {lake} {./build/bin/greeting} }}` resu
 ## Lakefiles
 -->
 
-## Lakefile 构建文件
+## Lakefile 构建文件 { #lakefiles }
 
 <!--
 A `lakefile.lean` describes a _package_, which is a coherent collection of Lean code for distribution, analogous to an `npm` or `nuget` package or a Rust crate.
@@ -199,7 +199,7 @@ To build a target that is not annotated with `@[default_target]`, specify the ta
 ## Libraries and Imports
 -->
 
-## 库与导入
+## 库与导入 { #libraries-and-imports }
 
 <!--
 A Lean library consists of a hierarchically organized collection of source files from which names can be imported, called _modules_.

--- a/functional-programming-lean/src/hello-world/step-by-step.md
+++ b/functional-programming-lean/src/hello-world/step-by-step.md
@@ -2,7 +2,7 @@
 # Step By Step
 -->
 
-# 逐步执行
+# 逐步执行 { #step-by-step }
 
 <!--
 A `do` block can be executed one line at a time.
@@ -19,7 +19,7 @@ Start with the program from the prior section:
 ## Standard IO
 -->
 
-## 标准 IO
+## 标准 IO { #standard-io }
 
 <!--
 The first line is `{{#include ../../../examples/hello-name/HelloName.lean:line1}}`, while the remainder is:
@@ -59,7 +59,7 @@ Finally, this value is associated with the name `stdout` for the remainder of th
 ## Asking a Question
 -->
 
-## 提问
+## 提问 { #asking-a-question }
 
 <!--
 Now that `stdin` and `stdout` have been found, the remainder of the block consists of a question and an answer:
@@ -86,7 +86,7 @@ Statements that consist only of expressions do not introduce any new variables.
 该代码块中的第一个语句 `{{#include ../../../examples/hello-name/HelloName.lean:line3}}`
 由一个表达式组成。要执行一个表达式，首先要对其进行求值。在这种情况下，`IO.FS.Stream.putStrLn`
 的类型为 `IO.FS.Stream → String → IO Unit`。这意味着它是一个接受流和字符串并返回 `IO` 活动的函数。
-该表达式使用[访问器记法](../getting-to-know/structures.md#幕后)进行函数调用。
+该表达式使用[访问器记法](../getting-to-know/structures.md#behind-the-scenes)进行函数调用。
 此函数应用于两个参数：标准输出流和字符串。表达式的值为一个 `IO` 活动，
 该活动将字符串和换行符写入输出流。得到此值后，下一步是执行它，这会导致字符串和换行符写入到
 `stdout`。仅由表达式组成的语句不会引入任何新变量。
@@ -170,7 +170,7 @@ In the current line of the program, whitespace characters (including the newline
 ## Greeting the User
 -->
 
-## 向用户问好
+## 向用户问好 { #greeting-the-user }
 
 <!--
 All that remains to be executed in the `do` block is a single statement:
@@ -200,7 +200,7 @@ Once the expression has been evaluated, the resulting `IO` action is executed, r
 ## `IO` Actions as Values
 -->
 
-## `IO` 活动作为值
+## `IO` 活动作为值 { #io-actions-as-values }
 
 <!--
 In the above description, it can be difficult to see why the distinction between evaluating expressions and executing `IO` actions is necessary.
@@ -378,7 +378,7 @@ The final step, `pure ()`, does not have any effects, and it is only present bec
 ## Exercise
 -->
 
-## 练习
+## 练习 { #exercise }
 
 <!--
 Step through the execution of the following program on a piece of paper:

--- a/functional-programming-lean/src/hello-world/summary.md
+++ b/functional-programming-lean/src/hello-world/summary.md
@@ -2,13 +2,13 @@
 # Summary
 -->
 
-# 总结
+# 总结 { #summary }
 
 <!--
 ## Evaluation vs Execution
 -->
 
-## 求值与执行
+## 求值与执行 { #evaluation-vs-execution }
 
 <!--
 Side effects are aspects of program execution that go beyond the evaluation of mathematical expressions, such as reading files, throwing exceptions, or triggering industrial machinery.
@@ -53,7 +53,7 @@ An `IO` action `main` is executed when the program starts.
 ## `do` Notation
 -->
 
-## `do` 记法
+## `do` 记法 { #do-notation }
 
 <!--
 The Lean standard library provides a number of basic `IO` actions that represent effects such as reading from and writing to files and interacting with standard input and standard output.
@@ -99,7 +99,7 @@ Lean 编译器会隐式地将它们提升到最近的封闭 `do` 中，该 `do` 
 ## Compiling and Running Programs
 -->
 
-## 编译并运行程序
+## 编译并运行程序 { #compiling-and-running-programs }
 
 <!--
 A Lean program that consists of a single file with a `main` definition can be run using `lean --run FILE`.
@@ -127,7 +127,7 @@ Lean 项目被组织成 **包（Package）** ，它们是库和可执行文件�
 ## Partiality
 -->
 
-## 偏函数
+## 偏函数 { #partiality }
 
 <!--
 One consequence of following the mathematical model of expression evaluation is that every expression must have a value.

--- a/functional-programming-lean/src/introduction.md
+++ b/functional-programming-lean/src/introduction.md
@@ -1,10 +1,4 @@
 <!--
-# Introduction
--->
-
-# 引言
-
-<!--
 Lean is an interactive theorem prover developed at Microsoft Research, based on dependent type theory.
 Dependent type theory unites the worlds of programs and proofs; thus, Lean is also a programming language.
 Lean takes its dual nature seriously, and it is designed to be suitable for use as a general-purpose programming language—Lean is even implemented in itself.
@@ -80,7 +74,7 @@ It is also useful to explore Lean as you read the book, finding creative new way
 # Getting Lean
 -->
 
-# 获取 Lean
+# 获取 Lean { #getting-lean }
 
 <!--
 Before writing and running programs written in Lean, you'll need to set up Lean on your own computer.
@@ -113,7 +107,7 @@ Please refer to the [Lean manual](https://lean-lang.org/lean4/doc/quickstart.htm
 # Typographical Conventions
 -->
 
-# 排版约定
+# 排版约定 { #typographical-conventions }
 
 <!--
 Code examples that are provided to Lean as _input_ are formatted like this:
@@ -158,7 +152,7 @@ Warnings are formatted like this:
 declaration uses 'sorry'
 ```
 
-# Unicode
+# Unicode { #unicode }
 
 <!--
 Idiomatic Lean code makes use of a variety of Unicode characters that are not part of ASCII.

--- a/functional-programming-lean/src/monad-transformers.md
+++ b/functional-programming-lean/src/monad-transformers.md
@@ -1,7 +1,7 @@
 <!--
 # Monad Transformers
 -->
-# 单子转换器
+# 单子转换器 { #monad-transformers }
 
 <!--
 A monad is a way to encode some collection of side effects in a pure language.

--- a/functional-programming-lean/src/monad-transformers/conveniences.md
+++ b/functional-programming-lean/src/monad-transformers/conveniences.md
@@ -1,12 +1,12 @@
 <!--
 # Additional Conveniences
 -->
-# 其他便利功能
+# 其他便利功能 { #additional-conveniences }
 
 <!--
 ## Pipe Operators
 -->
-## 管道操作符
+## 管道操作符 { #pipe-operators }
 
 <!--
 Functions are normally written before their arguments.
@@ -113,7 +113,7 @@ Lean 的方法点符号（Dot notation）使用点前的类型名称来解析点
 <!--
 ## Infinite Loops
 -->
-## 无限循环
+## 无限循环 { #infinite-loops }
 
 <!--
 Within a `do`-block, the `repeat` keyword introduces an infinite loop.
@@ -157,7 +157,7 @@ Partiality does not "infect" calling functions.
 <!--
 ## While Loops
 -->
-## While 循环
+## While 循环 { #while-loops }
 
 <!--
 When programming with local mutability, `while` loops can be a convenient alternative to `repeat` with an `if`-guarded `break`:
@@ -170,4 +170,3 @@ When programming with local mutability, `while` loops can be a convenient altern
 Behind the scenes, `while` is just a simpler notation for `repeat`.
 -->
 在后端， `while` 只是 `repeat` 的一个更简单的标记。
-

--- a/functional-programming-lean/src/monad-transformers/do.md
+++ b/functional-programming-lean/src/monad-transformers/do.md
@@ -1,7 +1,7 @@
 <!--
 # More do Features
 -->
-# 更多 do 的特性
+# 更多 do 的特性 { #more-do-features }
 <!--
 Lean's `do`-notation provides a syntax for writing programs with monads that resembles imperative programming languages.
 In addition to providing a convenient syntax for programs with monads, `do`-notation provides syntax for using certain monad transformers.
@@ -12,7 +12,7 @@ Lean 的 `do`-标记为使用单子编写程序提供了一种类似命令式编
 <!--
 ## Single-Branched `if`
 -->
-## 单分支 `if`
+## 单分支 `if` { #single-branched-if }
 
 <!--
 When working in a monad, a common pattern is to carry out a side effect only if some condition is true.
@@ -65,7 +65,7 @@ The remaining extensions in this section, however, require Lean to automatically
 <!--
 ## Early Return
 -->
-## 提前返回
+## 提前返回 { #early-return }
 
 <!--
 The standard library contains a function `List.find?` that returns the first entry in a list that satisfies some check.
@@ -187,7 +187,7 @@ the expression `{{#example_in Examples/MonadTransformers/Do.lean greetDavid}}` e
 <!--
 ## Loops
 -->
-## 循环
+## 循环 { #loops }
 
 <!--
 Just as every program with mutable state can be rewritten to a program that passes the state as arguments, every loop can be rewritten as a recursive function.
@@ -209,7 +209,7 @@ If the loop terminates without having returned, the answer is `none`.
 <!--
 ### Looping with ForM
 -->
-### 使用 ForM 循环
+### 使用 ForM 循环 { #looping-with-form }
 
 <!--
 Lean includes a type class that describes looping over a container type in some monad.
@@ -326,7 +326,7 @@ $ {{#command {formio} {formio} {lean --run ForMIO.lean < test-data}}}
 <!--
 ### Stopping Iteration
 -->
-### 中止循环
+### 中止循环 { #stopping-iteration }
 
 <!--
 Terminating a loop early is difficult to do with `forM`.
@@ -499,7 +499,7 @@ produces three lines of output:
 <!--
 ## Mutable Variables
 -->
-## 可变变量
+## 可变变量 { #mutable-variables }
 
 <!--
 In addition to early `return`, `else`-less `if`, and `for` loops, Lean supports local mutable variables within a `do` block.
@@ -582,7 +582,7 @@ This is because the recursive function is written in the identity monad, and onl
 <!--
 ## What counts as a `do` block?
 -->
-## 什么算作 `do` 区块？
+## 什么算作 `do` 区块？ { #what-counts-as-a-do-block }
 
 <!--
 Many features of `do`-notation apply only to a single `do`-block.
@@ -683,7 +683,7 @@ These programs are also accepted:
 <!--
 ## Imperative or Functional Programming?
 -->
-## 命令式还是函数式编程？
+## 命令式还是函数式编程？ { #imperative-or-functional-programming }
 
 <!--
 The imperative features provided by Lean's `do`-notation allow many programs to very closely resemble their counterparts in languages like Rust, Java, or C#.
@@ -700,7 +700,7 @@ Lean 的 `do`-标记提供的命令式特性让许多程序与 Rust、Java 或 C
 <!--
 ## Exercises
 -->
-## 练习
+## 练习 { #exercises }
 
 <!--
 * Rewrite `doug` to use `for` instead of the `doList` function. Are there other opportunities to use the features introduced in this section to improve the code? If so, use them!

--- a/functional-programming-lean/src/monad-transformers/order.md
+++ b/functional-programming-lean/src/monad-transformers/order.md
@@ -1,7 +1,7 @@
 <!--
 # Ordering Monad Transformers
 -->
-# 对单子转换器排序
+# 对单子转换器排序 { #ordering-monad-transformers }
 
 <!--
 When composing a monad from a stack of monad transformers, it's important to be aware that the order in which the monad transformers are layered matters.
@@ -152,7 +152,7 @@ When an exception is thrown in `M2`, it is accompanied by a state.
 <!--
 ## Commuting Monads
 -->
-## 交换单子
+## 交换单子 { #commuting-monads }
 
 <!--
 In the jargon of functional programming, two monad transformers are said to _commute_ if they can be re-ordered without the meaning of the program changing.
@@ -194,7 +194,7 @@ With great expressive power comes the responsibility to check that what's being 
 <!--
 ## Exercises
 -->
-## 练习
+## 练习 { #exercises }
 
 <!--
  * Check that `ReaderT` and `StateT` commute by expanding their definitions and reasoning about the resulting types.

--- a/functional-programming-lean/src/monad-transformers/reader-io.md
+++ b/functional-programming-lean/src/monad-transformers/reader-io.md
@@ -1,7 +1,7 @@
 <!--
 # Combining IO and Reader
 -->
-# 组合 IO 与 Reader
+# 组合 IO 与 Reader { #combining-io-and-reader }
 
 <!--
 One case where a reader monad can be useful is when there is some notion of the "current configuration" of the application that is passed through many recursive calls.
@@ -39,7 +39,7 @@ $ {{#command {doug-demo} {doug} {doug} }}
 <!--
 ## Implementation
 -->
-## 实现
+## 实现 { #implementation }
 
 <!--
 Internally, `doug` passes a configuration value downwards as it recursively traverses the directory structure.
@@ -182,7 +182,7 @@ Because `doList` carries out all the actions in a list and does not base control
 <!--
 ## Using a Custom Monad
 -->
-## 使用自定义单子
+## 使用自定义单子 { #using-a-custom-monad }
 
 <!--
 While this implementation of `doug` works, manually passing the configuration around is verbose and error-prone.
@@ -330,7 +330,7 @@ Monad transformers consist of:
 <!--
 ## Adding a Reader to Any Monad
 -->
-## 将读取器添加到任意单子
+## 将读取器添加到任意单子 { #adding-a-reader-to-any-monad }
 
 <!--
 Adding a reader effect to `IO` was accomplished in `ConfigIO` by wrapping `IO α` in a function type.
@@ -498,12 +498,12 @@ Just as some functions work in any monad, others can work in any monad that prov
 <!--
 ## Exercises
 -->
-## 练习
+## 练习 { #exercises }
 
 <!--
 ### Controlling the Display of Dotfiles
 -->
-### 控制点文件的显示
+### 控制点文件的显示 { #controlling-the-display-of-dotfiles }
 
 <!--
 Files whose names begin with a dot character (`'.'`) typically represent files that should usually be hidden, such as source-control metadata and configuration files.
@@ -517,7 +517,7 @@ This option should be controlled with a `-a` command-line option.
 <!--
 ### Starting Directory as Argument
 -->
-### 起始目录作为参数
+### 起始目录作为参数 { #starting-directory-as-argument }
 
 <!--
 Modify `doug` so that it takes a starting directory as an additional command-line argument.

--- a/functional-programming-lean/src/monad-transformers/summary.md
+++ b/functional-programming-lean/src/monad-transformers/summary.md
@@ -1,12 +1,12 @@
 <!--
 # Summary
 -->
-# 总结
+# 总结 { #summary }
 
 <!--
 ## Combining Monads
 -->
-## 组合单子
+## 组合单子 { #combining-monads }
 
 <!--
 When writing a monad from scratch, there are design patterns that tend to describe the ways that each effect is added to the monad.
@@ -39,7 +39,7 @@ Monad transformers may be implemented as polymorphic structures or inductive dat
 <!--
 ## Type Classes for Effects
 -->
-## 作用的类型类
+## 作用的类型类 { #type-classes-for-effects }
 
 <!--
 A common design pattern is to implement a particular effect by defining a monad that has the effect, a monad transformer that adds it to another monad, and a type class that provides a generic interface to the effect.
@@ -60,7 +60,7 @@ Thus, both versions are typically provided, with the ordinary-parameter version 
 <!--
 ## Monad Transformers Don't Commute
 -->
-## 单子转换器不可交换
+## 单子转换器不可交换 { #monad-transformers-dont-commute }
 
 <!--
 It is important to note that changing the order of transformers in a monad can change the meaning of programs that use the monad.
@@ -74,7 +74,7 @@ While most imperative languages provide only the latter, the increased flexibili
 <!--
 ## `do`-Notation for Monad Transformers
 -->
-## 单子转换器的 `do`-标记
+## 单子转换器的 `do`-标记 { #do-notation-for-monad-transformers }
 <!--
 Lean's `do`-blocks support early return, in which the block is terminated with some value, locally mutable variables, `for`-loops with `break` and `continue`, and single-branched `if`-statements.
 While this may seem to be introducing imperative features that would get in the way of using Lean to write proofs, it is in fact nothing more than a more convenient syntax for certain common uses of monad transformers.

--- a/functional-programming-lean/src/monad-transformers/transformers.md
+++ b/functional-programming-lean/src/monad-transformers/transformers.md
@@ -1,7 +1,7 @@
 <!--
 # A Monad Construction Kit
 -->
-# 单子构建工具包
+# 单子构建工具包 { #a-monad-construction-kit }
 
 <!--
 `ReaderT` is far from the only useful monad transformer.
@@ -43,7 +43,7 @@ The type classes are a way for programs to express their requirements, and monad
 <!--
 ## Failure with `OptionT`
 -->
-## 使用 `OptionT` 失败
+## 使用 `OptionT` 失败 { #failure-with-optiont }
 
 <!--
 Failure, represented by the `Option` monad, and exceptions, represented by the `Except` monad, both have corresponding transformers.
@@ -102,7 +102,7 @@ The main function, `interact`, invokes `getUserInfo` in a purely `IO` context, w
 <!--
 ### The Monad Instance
 -->
-### 单子实例
+### 单子实例 { #the-monad-instance }
 
 <!--
 Writing the monad instance reveals a difficulty.
@@ -221,7 +221,7 @@ It can be checked in the same way, by expanding the definitions of `bind` and `p
 <!--
 ### An `Alternative` Instance
 -->
-### 一个 `Alternative` 实例
+### 一个 `Alternative` 实例 { #an-alternative-instance }
 
 <!--
 One convenient way to use `OptionT` is through the `Alternative` type class.
@@ -238,7 +238,7 @@ Successful return is already indicated by `pure`, and the `failure` and `orElse`
 <!--
 ### Lifting
 -->
-### 提升
+### 提升 { #lifting }
 
 <!--
 Lifting an action from `m` to `OptionT m` only requires wrapping `some` around the result of the computation:
@@ -252,7 +252,7 @@ Lifting an action from `m` to `OptionT m` only requires wrapping `some` around t
 <!--
 ## Exceptions
 -->
-## 异常
+## 异常 { #exceptions }
 
 <!--
 The monad transformer version of `Except` is very similar to the monad transformer version of `Option`.
@@ -335,7 +335,7 @@ This can be accomplished using the fact that `Functor` is a superclass of `Monad
 <!--
 ### Type Classes for Exceptions
 -->
-### 异常的类型类
+### 异常的类型类 { #type-classes-for-exceptions }
 
 <!--
 Exception handling fundamentally consists of two operations: the ability to throw exceptions, and the ability to recover from them.
@@ -425,7 +425,7 @@ For example, failure due to `Option` can be seen as throwing an exception that c
 <!--
 ## State
 -->
-## 状态
+## 状态 { #state }
 
 <!--
 A simulation of mutable state is added to a monad by having monadic actions accept a starting state as an argument and return a final state together with their result.
@@ -512,7 +512,7 @@ While it would be possible to provide a default implementation of `modifyGet` in
 <!--
 ## `Of` Classes and `The` Functions
 -->
-## `Of` 类和 `The` 函数
+## `Of` 类和 `The` 函数 { #of-classes-and-the-functions }
 
 <!--
 Thus far, each monad type class that takes extra information, like the type of exceptions for `MonadExcept` or the type of the state for `MonadState`, has this type of extra information as an output parameter.
@@ -567,7 +567,7 @@ It's generally a good idea to implement the `Of` version, and then start writing
 <!--
 ## Transformers and `Id`
 -->
-## 转换器和 `Id`
+## 转换器和 `Id` { #transformers-and-id }
 
 <!--
 The identity monad `Id` is the monad that has no effects whatsoever, to be used in contexts that expect a monad for some reason but where none is actually necessary.
@@ -581,12 +581,12 @@ For instance, `StateT σ Id` works just like `State σ`.
 <!--
 ## Exercises
 -->
-## 练习
+## 练习 { #exercises }
 
 <!--
 ### Monad Contract
 -->
-### 单子约定
+### 单子约定 { #monad-contract }
 <!--
 Using pencil and paper, check that the rules of the monad transformer contract are satisfied for each monad transformer in this section.
 -->
@@ -594,7 +594,7 @@ Using pencil and paper, check that the rules of the monad transformer contract a
 <!--
 ### Logging Transformer
 -->
-### 日志转换器
+### 日志转换器 { #logging-transformer }
 <!--
 Define a monad transformer version of `WithLog`.
 Also define the corresponding type class `MonadWithLog`, and write a program that combines logging and exceptions.
@@ -605,7 +605,7 @@ Also define the corresponding type class `MonadWithLog`, and write a program tha
 <!--
 ### Counting Files
 -->
-### 文件计数
+### 文件计数 { #counting-files }
 
 <!--
 Modify `doug`'s monad with `StateT` such that it counts the number of directories and files seen.

--- a/functional-programming-lean/src/monads.md
+++ b/functional-programming-lean/src/monads.md
@@ -1,4 +1,4 @@
-# Monads
+# Monads { #monads }
 
 <!--
 In C# and Kotlin, the `?.` operator is a way to look up a property or call a method on a potentially-null value.
@@ -36,7 +36,7 @@ Please suspend your disbelief in the meantime.
 ## Checking for `none`: Don't Repeat Yourself
 -->
 
-## 检查`none`：避免重复代码
+## 检查`none`：避免重复代码 { #checking-for-none-dont-repeat-yourself }
 
 <!--
 In Lean, pattern matching can be used to chain checks for null.
@@ -128,7 +128,7 @@ Improving the syntax used to write `andThen` can make these computations even ea
 ### Infix Operators
 -->
 
-### 中缀运算符
+### 中缀运算符 { #infix-operators }
 
 <!--
 In Lean, infix operators can be declared using the `infix`, `infixl`, and `infixr` commands, which create (respectively) non-associative, left-associative, and right-associative operators.
@@ -199,7 +199,7 @@ This style is much more concise when writing larger functions:
 ## Propagating Error Messages
 -->
 
-## 错误消息的传递
+## 错误消息的传递 { #propagating-error-messages }
 
 <!--
 Pure functional languages such as Lean have no built-in exception mechanism for error handling, because throwing or catching an exception is outside of the step-by-step evaluation model for expressions.
@@ -363,7 +363,7 @@ The technique scales similarly to larger functions:
 {{#example_decl Examples/Monads.lean firstThirdFifthSeventInfixExcept}}
 ```
 
-## 日志记录
+## 日志记录 { #logging }
 
 <!--
 A number is even if dividing it by 2 leaves no remainder:
@@ -472,7 +472,7 @@ And, once again, the infix operator helps put focus on the correct steps:
 ## Numbering Tree Nodes
 -->
 
-## 对树节点编号
+## 对树节点编号 { #numbering-tree-nodes }
 
 <!--
 An _inorder numbering_ of a tree associates each data point in the tree with the step it would be visited at in an inorder traversal of the tree.
@@ -611,7 +611,7 @@ Because `State` simulates only a single local variable, `get` and `set` don't ne
 ## Monads: A Functional Design Pattern
 -->
 
-## 单子：一种函数式设计模式
+## 单子：一种函数式设计模式 { #monads-a-functional-design-pattern }
 
 <!--
 Each of these examples has consisted of:
@@ -638,4 +638,3 @@ For example, `Option` represents programs that can fail by returning `none`, `Ex
 虽然单子的思想源自于一门称为范畴论的数学分支，但为了将它们用于编程，并不需要理解范畴论。
 单子的关键思想是，每个单子都使用纯函数式语言Lean提供的工具对特定类型的副作用进行编码。
 例如`Option`表示可能通过返回`none`而失败的程序，`Except`表示可能抛出异常的程序，`WithLog`表示在运行过程中累积日志的程序，`State`表示具有单个可变变量的程序。
-

--- a/functional-programming-lean/src/monads/arithmetic.md
+++ b/functional-programming-lean/src/monads/arithmetic.md
@@ -2,7 +2,7 @@
 ## Example: Arithmetic in Monads
 -->
 
-## 例子：利用单子实现算术表达式求值
+## 例子：利用单子实现算术表达式求值 { #example-arithmetic-in-monads }
 
 <!--
 Monads are a way of encoding programs with side effects into a language that does not have them.
@@ -29,7 +29,7 @@ One example of a program that can make sense in a variety of monads is an evalua
 ### Arithmetic Expressions
 -->
 
-### 算术表达式
+### 算术表达式 { #arithmetic-expressions }
 
 <!--
 An arithmetic expression is either a literal integer or a primitive binary operator applied to two expressions. The operators are addition, subtraction, multiplication, and division:
@@ -63,7 +63,7 @@ and `14 / (45 - 5 * 9)` is represented:
 ### Evaluating Expressions
 -->
 
-### 对表达式求值
+### 对表达式求值 { #evaluating-expressions }
 
 <!--
 Because expressions include division, and division by zero is undefined, evaluation might fail.
@@ -162,7 +162,7 @@ In this refactored code, the fact that the two code paths differ only in their t
 ### Further Effects
 -->
 
-### 额外的作用
+### 额外的作用 { #further-effects }
 
 <!--
 Failure and exceptions are not the only kinds of effects that can be interesting when working with an evaluator.
@@ -200,7 +200,7 @@ The second step is to broaden the scope of the division handler argument to `eva
 #### No Effects
 -->
 
-#### 无作用
+#### 无作用 { #no-effects }
 
 <!--
 The type `Empty` has no constructors, and thus no values, like the `Nothing` type in Scala or Kotlin.
@@ -247,7 +247,7 @@ This can be used together with `Id`, the identity monad, to evaluate expressions
 #### Nondeterministic Search
 -->
 
-#### 非确定性搜索
+#### 非确定性搜索 { #nondeterministic-search }
 
 <!--
 Instead of simply failing when encountering division by zero, it would also be sensible to backtrack and try a different input.
@@ -514,7 +514,7 @@ Using these operators, the earlier examples can be evaluated:
 #### Custom Environments
 -->
 
-#### 自定义环境
+#### 自定义环境 { #custom-environments }
 
 <!--
 The evaluator can be made user-extensible by allowing strings to be used as operators, and then providing a mapping from strings to a function that implements them.
@@ -830,13 +830,13 @@ Kotlin的上下文对象可以解决类似的问题，但根本上是一种自�
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 ### Checking Contracts
 -->
 
-### 检查约定
+### 检查约定 { #checking-contracts }
 
 <!--
 Check the monad contract for `State σ` and `Except ε`.
@@ -848,7 +848,7 @@ Check the monad contract for `State σ` and `Except ε`.
 ### Readers with Failure
 -->
 
-### 允许Reader失败
+### 允许Reader失败 { #readers-with-failure }
 <!--
 Adapt the reader monad example so that it can also indicate failure when the custom operator is not defined, rather than just returning zero.
 In other words, given these definitions:
@@ -879,7 +879,7 @@ do the following:
 ### A Tracing Evaluator
 -->
 
-### 带有跟踪信息的求值器
+### 带有跟踪信息的求值器 { #a-tracing-evaluator }
 
 <!--
 The `WithLog` type can be used with the evaluator to add optional tracing of some operations.

--- a/functional-programming-lean/src/monads/class.md
+++ b/functional-programming-lean/src/monads/class.md
@@ -2,7 +2,7 @@
 # The Monad Type Class
 -->
 
-# Monad类型类
+# Monad类型类 { #the-monad-type-class }
 
 <!--
 Rather than having to import an operator like `ok` or `andThen` for each type that is a monad, the Lean standard library contains a type class that allow them to be overloaded, so that the same operators can be used for _any_ monad.
@@ -108,7 +108,7 @@ The fact that `m` must have a `Monad` instance means that the `>>=` and `pure` o
 ## General Monad Operations
 -->
 
-## 通用的单子运算符
+## 通用的单子运算符 { #general-monad-operations }
 
 <!--
 Because many different types are monads, functions that are polymorphic over _any_ monad are very powerful.
@@ -141,7 +141,7 @@ The `Monad` class requires that its parameter expect a single type argument—th
 This means that the instance for `State` should mention the state type `σ`, which becomes a parameter to the instance:
 -->
 
-如[本章简介](../monads.md#对树节点编号)所介绍的，`State σ α`表示使用类型为 `σ` 的可变变量，并返回类型为 `α` 的值的程序。
+如[本章简介](../monads.md#numbering-tree-nodes)所介绍的，`State σ α`表示使用类型为 `σ` 的可变变量，并返回类型为 `α` 的值的程序。
 这些程序实际上是从起始状态到值和最终状态构成的对(pair)的函数。
 `Monad`类型类要求：类型参数期望另一个类型参数，即它应该是`Type → Type`。
 这意味着 `State` 的实例应提及状态类型`σ`，使它成为实例的参数：
@@ -185,7 +185,7 @@ A [logging effect](../monads.md#logging) can be represented using `WithLog`.
 Just like `State`, its `Monad` instance is polymorphic with respect to the type of the logged data:
 -->
 
-可以使用 `WithLog` 表示[日志记录效应](../monads.md#日志记录)。
+可以使用 `WithLog` 表示[日志记录效应](../monads.md#logging)。
 就和 `State` 一样，它的 `Monad` 实例对于被记录数据的类型也是多态的：
 
 ```lean
@@ -218,7 +218,7 @@ Using this function with `mapM` results in a log containing even numbers paired 
 ## The Identity Monad
 -->
 
-## 恒等单子
+## 恒等单子 { #the-identity-monad }
 
 <!--
 Monads encode programs with effects, such as failure, exceptions, or logging, into explicit representations as data and functions.
@@ -292,7 +292,7 @@ Similarly, using `mapM` with a function whose type doesn't provide any specific 
 ## The Monad Contract
 -->
 
-## 单子约定
+## 单子约定 { #the-monad-contract }
 <!--
 Just as every pair of instances of `BEq` and `Hashable` should ensure that any two equal values have the same hash, there is a contract that each instance of `Monad` should obey.
 First, `pure` should be a left identity of `bind`.
@@ -320,13 +320,13 @@ The associative property of `bind` basically says that the sequencing bookkeepin
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 ### Mapping on a Tree
 -->
 
-### 映射一棵树
+### 映射一棵树 { #mapping-on-a-tree }
 
 <!--
 Define a function `BinTree.mapM`.
@@ -346,7 +346,7 @@ def BinTree.mapM [Monad m] (f : α → m β) : BinTree α → m (BinTree β)
 ### The Option Monad Contract
 -->
 
-### Option单子的约定
+### Option单子的约定 { #the-option-monad-contract }
 
 <!--
 First, write a convincing argument that the `Monad` instance for `Option` satisfies the monad contract.

--- a/functional-programming-lean/src/monads/conveniences.md
+++ b/functional-programming-lean/src/monads/conveniences.md
@@ -2,13 +2,13 @@
 # Additional Conveniences
 -->
 
-# 其他便利功能
+# 其他便利功能 { #additional-conveniences }
 
 <!--
 ## Shared Argument Types
 -->
 
-## 共享参数类型
+## 共享参数类型 { #shared-argument-types }
 
 <!--
 When defining a function that takes multiple arguments that have the same type, both can be written before the same colon.
@@ -40,7 +40,7 @@ This is especially useful when the type signature is large.
 ## Leading Dot Notation
 -->
 
-## 开头的点号
+## 开头的点号 { #leading-dot-notation }
 
 <!--
 The constructors of an inductive type are in a namespace.
@@ -89,7 +89,7 @@ If `BinTree.empty` is defined as an alternative way of creating `BinTree`s, then
 ## Or-Patterns
 -->
 
-## 或-模式
+## 或-模式 { #or-patterns }
 
 <!--
 In contexts that allow multiple patterns, such as `match`-expressions, multiple patterns may share their result expressions.

--- a/functional-programming-lean/src/monads/do.md
+++ b/functional-programming-lean/src/monads/do.md
@@ -2,7 +2,7 @@
 # `do`-Notation for Monads
 -->
 
-# 单子的 `do`-记法
+# 单子的 `do`-记法 { #do-notation-for-monads }
 
 <!--
 While APIs based on monads are very powerful, the explicit use of `>>=` with anonymous functions is still somewhat noisy.
@@ -182,7 +182,7 @@ Using nested actions, `number` can be made much more concise:
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
  * Rewrite `evaluateM`, its helpers, and the different specific use cases using `do`-notation instead of explicit calls to `>>=`.

--- a/functional-programming-lean/src/monads/io.md
+++ b/functional-programming-lean/src/monads/io.md
@@ -2,7 +2,7 @@
 # The IO Monad
 -->
 
-# IO 单子
+# IO 单子 { #the-io-monad }
 
 <!--
 `IO` as a monad can be understood from two perspectives, which were described in the section on [running programs](../hello-world/running-a-program.md).

--- a/functional-programming-lean/src/monads/summary.md
+++ b/functional-programming-lean/src/monads/summary.md
@@ -2,13 +2,13 @@
 # Summary
 -->
 
-# 总结
+# 总结 { #summary }
 
 <!--
 ## Encoding Side Effects
 -->
 
-## 编码副作用
+## 编码副作用 { #encoding-side-effects }
 
 <!--
 Lean is a pure functional language.
@@ -37,7 +37,7 @@ Lean 类型签名不仅描述了函数期望的参数类型和它返回的结果
 ## The Monad Type Class
 -->
 
-## 单子类型类
+## 单子类型类 { #the-monad-type-class }
 
 <!--
 It's possible to write purely functional programs in languages that allow effects anywhere.
@@ -64,7 +64,7 @@ The contract for `Monad` instances ensures that `bind` and `pure` actually captu
 ## `do`-Notation for Monads
 -->
 
-## 单子的 `do`-记法
+## 单子的 `do`-记法 { #do-notation-for-monads }
 
 <!--
 Rather than being limited to `IO`, `do`-notation works for any monad.
@@ -82,7 +82,7 @@ A program written with `do` is translated to applications of `>>=` behind the sc
 ## Custom Monads
 -->
 
-## 定制单子
+## 定制单子 { #custom-monads }
 
 <!--
 Different languages provide different sets of side effects.
@@ -103,7 +103,7 @@ Because Lean is designed to make programming with any monad convenient, programm
 ## The `IO` Monad
 -->
 
-## `IO` 单子
+## `IO` 单子 { #the-io-monad }
 
 <!--
 Programs that can affect the real world are written as `IO` actions in Lean.

--- a/functional-programming-lean/src/next-steps.md
+++ b/functional-programming-lean/src/next-steps.md
@@ -2,7 +2,7 @@
 # Next Steps
 -->
 
-# 下一步
+# 下一步 { #next-steps }
 
 <!--
 This book introduces the very basics of functional programming in Lean, including a tiny amount of interactive theorem proving. Using dependently-typed functional languages like Lean is a deep topic, and much can be said. Depending on your interests, the following resources might be useful for learning Lean 4.
@@ -16,7 +16,7 @@ This book introduces the very basics of functional programming in Lean, includin
 ### Learning Lean
 -->
 
-### 学习 Lean
+## 学习 Lean { #learning-lean }
 
 <!--
 Lean 4 itself is described in the following resources:
@@ -47,10 +47,10 @@ Lean 4 本身在以下资源中有详细描述：
 寻求帮助和帮助他人的好地方。
 
 <!--
-### The Standard Library
+## The Standard Library
 -->
 
-### 标准库
+## 标准库 { #the-standard-library }
 
 <!--
 Out of the box, Lean itself includes a fairly minimal library. Lean is self-hosted, and the included code is just enough to implement Lean itself. For many applications, a larger standard library is needed.
@@ -75,10 +75,10 @@ require std from git
 ```
 
 <!--
-### Mathematics in Lean
+## Mathematics in Lean
 -->
 
-### Lean 形式化数学
+## Lean 形式化数学 { #mathematics-in-lean }
 
 <!--
 Most resources for mathematicians are written for Lean 3. A wide selection are available at the community site. To get started doing mathematics in Lean 4, it is probably easiest to participate in the process of porting the mathematics library mathlib from Lean 3 to Lean 4. Please see the mathlib4 README for further information.
@@ -90,10 +90,10 @@ Most resources for mathematicians are written for Lean 3. A wide selection are a
 有关更多信息，请参阅 [mathlib4 的 README](https://github.com/leanprover-community/mathlib4).
 
 <!--
-### Using Dependent Types in Computer Science
+## Using Dependent Types in Computer Science
 -->
 
-### 在计算机科学中使用依值类型
+## 在计算机科学中使用依值类型 { #using-dependent-types-in-computer-science }
 
 <!--
 Coq is a language that has a lot in common with Lean. For computer scientists, the Software Foundations series of interactive textbooks provides an excellent introduction to applications of Coq in computer science. The fundamental ideas of Lean and Coq are very similar, and skills are readily transferable between the systems.
@@ -105,10 +105,10 @@ Coq 是一种与 Lean 有许多共同点的语言。对于计算机科学家来�
 编程技巧在两个语言之间是可以相互转换的。
 
 <!--
-### Programming with Dependent Types
+## Programming with Dependent Types
 -->
 
-### 使用依值类型编程
+## 使用依值类型编程 { #programming-with-dependent-types }
 
 <!--
 For programmers who are interested in learning to use indexed families and dependent types to structure programs, Edwin Brady's Type Driven Development with Idris provides an excellent introduction. Like Coq, Idris is a close cousin of Lean, though it lacks tactics.
@@ -119,10 +119,10 @@ For programmers who are interested in learning to use indexed families and depen
 提供了一个很好的介绍。和 Coq 一样，Idris 是 Lean 的近亲语言，但是它缺乏策略。
 
 <!--
-### Understanding Dependent Types
+## Understanding Dependent Types
 -->
 
-### 理解依值类型
+## 理解依值类型 { #understanding-dependent-types }
 
 <!--
 The Little Typer is a book for programmers who haven't formally studied logic or the theory of programming languages, but who want to build an understanding of the core ideas of dependent type theory. While all of the above resources aim to be as practical as possible, The Little Typer presents an approach to dependent type theory where the very basics are built up from scratch, using only concepts from programming. Disclaimer: the author of Functional Programming in Lean is also an author of The Little Typer.

--- a/functional-programming-lean/src/programs-proofs.md
+++ b/functional-programming-lean/src/programs-proofs.md
@@ -2,7 +2,7 @@
 # Programming, Proving, and Performance
 -->
 
-# 编程、证明与性能
+# 编程、证明与性能 { #programming-proving-and-performance }
 
 <!--
 This chapter is about programming.

--- a/functional-programming-lean/src/programs-proofs/arrays-termination.md
+++ b/functional-programming-lean/src/programs-proofs/arrays-termination.md
@@ -2,7 +2,7 @@
 # Arrays and Termination
 -->
 
-# 数组与停机性
+# 数组与停机性 { #arrays-and-termination }
 
 <!--
 To write efficient code, it is important to select appropriate data structures.
@@ -39,7 +39,7 @@ Both of these are expressed using an inequality proposition, rather than proposi
 ## Inequality
 -->
 
-## 不等式
+## 不等式 { #inequality }
 
 <!--
 Because different types have different notions of ordering, inequality is governed by two type classes, called `LE` and `LT`.
@@ -47,7 +47,7 @@ The table in the section on [standard type classes](../type-classes/standard-cla
 -->
 
 由于不同的类型有不同的序概念，不等式需要由两个类来控制，分别称为 `LE` 和 `LT`。
-[标准类型类](../type-classes/standard-classes.md#相等性与有序性)
+[标准类型类](../type-classes/standard-classes.md#equality-and-ordering)
 一节中的表格描述了这些类与语法的关系：
 
 <!--
@@ -93,7 +93,7 @@ Defining `Nat.le` requires a feature of Lean that has not yet been presented: it
 ### Inductively-Defined Propositions, Predicates, and Relations
 -->
 
-### 归纳定义的命题、谓词和关系
+### 归纳定义的命题、谓词和关系 { #inductively-defined-propositions-predicates-and-relations }
 
 <!--
 `Nat.le` is an _inductively-defined relation_.
@@ -167,7 +167,7 @@ The inductively-defined predicate `IsThree` states that its argument is three:
 The mechanism used here is just like [indexed families such as `HasCol`](../dependent-types/typed-queries.md#column-pointers), except the resulting type is a proposition that can be proved rather than data that can be used.
 -->
 
-这里使用的机制就像[索引族，如 `HasCol`](../dependent-types/typed-queries.md#列指针)，
+这里使用的机制就像[索引族，如 `HasCol`](../dependent-types/typed-queries.md#column-pointers)，
 只不过结果类型是一个可以被证明的命题，而非可以被使用的数据。
 
 <!--
@@ -288,7 +288,7 @@ As described in [the initial Interlude on proofs](../props-proofs-indexing.md#co
 
 标准假命题 `False` 没有构造子，因此无法提供直接证据。
 为 `False` 提供证据的唯一方法是假设本身不可能，类似于用 `nomatch`
-来标记类型系统认为无法访问的代码。如 [插曲中的证明一节](../props-proofs-indexing.md#连词)
+来标记类型系统认为无法访问的代码。如 [插曲中的证明一节](../props-proofs-indexing.md#connectives)
 所述，否定 `Not A` 是 `A → False` 的缩写。`Not A` 也可以写成 `¬A`。
 
 <!--
@@ -362,7 +362,7 @@ Just as a pattern match on a `Vect String 2` doesn't need to include a case for 
 ### Inequality of Natural Numbers
 -->
 
-### 自然数不等式
+### 自然数不等式 { #inequality-of-natural-numbers }
 
 <!--
 The definition of `Nat.le` has a parameter and an index:
@@ -428,7 +428,7 @@ This is because `4 < 7` is equivalent to `5 ≤ 7`.
 ## Proving Termination
 -->
 
-## 停机性证明
+## 停机性证明 { #proving-termination }
 
 <!--
 The function `Array.map` transforms an array with a function, returning a new array that contains the result of applying the function to each element of the input array.
@@ -556,7 +556,7 @@ Sometimes, creativity can be required in order to figure out just why a function
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
  * Implement a `ForM (Array α)` instance on arrays using a tail-recursive accumulator-passing function and a `termination_by` clause.

--- a/functional-programming-lean/src/programs-proofs/fin.md
+++ b/functional-programming-lean/src/programs-proofs/fin.md
@@ -2,7 +2,7 @@
 # Safe Array Indices
 -->
 
-# 安全数组索引
+# 安全数组索引 { #safe-array-indices }
 
 <!--
 The `GetElem` instance for `Array` and `Nat` requires a proof that the provided `Nat` is smaller than the array.
@@ -71,7 +71,7 @@ A more specific type results in a value that can be used without making the prog
 ## Exercise
 -->
 
-## 练习
+## 练习 { #exercise }
 
 <!--
 Write a function `Fin.next? : Fin n → Option (Fin n)` that returns the next largest `Fin` when it would be in bounds, or `none` if not.

--- a/functional-programming-lean/src/programs-proofs/inequalities.md
+++ b/functional-programming-lean/src/programs-proofs/inequalities.md
@@ -2,7 +2,7 @@
 # More Inequalities
 -->
 
-# 更多不等式
+# 更多不等式 { #more-inequalities }
 
 <!--
 Lean's built-in proof automation is sufficient to check that `arrayMapHelper` and `findHelper` terminate.
@@ -18,7 +18,7 @@ Lean 的内置证明自动化足以检查 `arrayMapHelper` 和 `findHelper` 是�
 ## Merge Sort
 -->
 
-## 归并排序
+## 归并排序 { #merge-sort }
 
 一个停机证明非平凡的函数示例是 `List` 上的归并排序。归并排序包含两个阶段：
 首先，将列表分成两半。使用归并排序对每一半进行排序，
@@ -135,7 +135,7 @@ Instead of complaining that the function isn't structurally recursive, Lean inst
 ## Splitting a List Makes it Shorter
 -->
 
-## 分割列表使其变短
+## 分割列表使其变短 { #splitting-a-list-makes-it-shorter }
 
 <!--
 It will also be necessary to prove that `(splitList xs).snd.length < xs.length`.
@@ -306,7 +306,7 @@ It's time to prove that these wrappings of `Nat.succ` preserve the truth of the 
 ### Adding One to Both Sides
 -->
 
-### 两边同时加一
+### 两边同时加一 { #adding-one-to-both-sides }
 
 <!--
 For the `left` goal, the statement to prove is `Nat.succ_le_succ : n ≤ m → Nat.succ n ≤ Nat.succ m`.
@@ -437,7 +437,7 @@ Which proof steps correspond to which parts of the definition?
 ### Adding One to the Greater Side
 -->
 
-### 在较大的一侧加一
+### 在较大的一侧加一 { #adding-one-to-the-greater-side }
 
 <!--
 The second inequality needed to prove `splitList_shorter_le` is `∀(n m : Nat), n ≤ m → n ≤ Nat.succ m`.
@@ -517,7 +517,7 @@ The recursive function is typically both harder to understand from the perspecti
 ### Finishing the Proof
 -->
 
-### 完成证明
+### 完成证明 { #finishing-the-proof }
 
 <!--
 Now that both helper theorems have been proved, the rest of `splitList_shorter_le` will be completed quickly.
@@ -659,7 +659,7 @@ The facts needed to prove that `mergeSort` terminates can be pulled out of the r
 ## Merge Sort Terminates
 -->
 
-## 归并排序停机证明
+## 归并排序停机证明 { #merge-sort-terminates }
 
 <!--
 Merge sort has two recursive calls, one for each sub-list returned by `splitList`.
@@ -796,7 +796,7 @@ The function can be tested on examples:
 ## Division as Iterated Subtraction
 -->
 
-## 用减法迭代表示除法
+## 用减法迭代表示除法 { #division-as-iterated-subtraction }
 
 <!--
 Just as multiplication is iterated addition and exponentiation is iterated multiplication, division can be understood as iterated subtraction.
@@ -805,7 +805,7 @@ Proving that division terminates requires the use of a fact about inequalities.
 -->
 
 正如乘法是迭代的加法，指数是迭代的乘法，除法可以理解为迭代的减法。
-[本书中对递归函数的第一个描述](../getting-to-know/datatypes-and-patterns.md#递归函数)
+[本书中对递归函数的第一个描述](../getting-to-know/datatypes-and-patterns.md#recursive-functions)
 给出了除法的一个版本，当除数不为零时停机，但 Lean 并不接受。证明除法终止需要使用关于不等式的事实。
 
 <!--
@@ -892,7 +892,7 @@ The full definition of `div`, including the termination proof, is:
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 Prove the following theorems:

--- a/functional-programming-lean/src/programs-proofs/insertion-sort.md
+++ b/functional-programming-lean/src/programs-proofs/insertion-sort.md
@@ -2,7 +2,7 @@
 # Insertion Sort and Array Mutation
 -->
 
-# 插入排序与数组可变性
+# 插入排序与数组可变性 { #insertion-sort-and-array-mutation }
 
 <!--
 While insertion sort does not have the optimal worst-case time complexity for a sorting algorithm, it still has a number of useful properties:
@@ -138,7 +138,7 @@ In other words, each iteration inserts the next element of the array into the ap
 ## The Inner Loop
 -->
 
-## 内层循环
+## 内层循环 { #the-inner-loop }
 
 <!--
 The inner loop of insertion sort can be implemented as a tail-recursive function that takes the array and the index of the element being inserted as arguments.
@@ -219,7 +219,7 @@ The `simp` tactic's database contains the fact that swapping two elements of an 
 ## The Outer Loop
 -->
 
-## 外层循环
+## 外层循环 { #the-outer-loop }
 
 <!--
 The outer loop of insertion sort moves the pointer from left to right, invoking `insertSorted` at each iteration to insert the element at the pointer into the correct position in the array.
@@ -274,7 +274,7 @@ Before constructing the termination proof, it can be convenient to test the defi
 ### Termination
 -->
 
-### 停机性
+### 停机性 { #termination }
 
 <!--
 Once again, the function terminates because the difference between the index and the size of the array being processed decreases on each recursive call.
@@ -619,7 +619,7 @@ It's type is `{{#example_out Examples/ProgramsProofs/InsertionSort.lean sub_succ
 ## The Driver Function
 -->
 
-## 驱动函数
+## 驱动函数 { #the-driver-function }
 
 <!--
 Insertion sort itself calls `insertionSortLoop`, initializing the index that demarcates the sorted region of the array from the unsorted region to `0`:
@@ -657,7 +657,7 @@ A few quick tests show the function is at least not blatantly wrong:
 ## Is This Really Insertion Sort?
 -->
 
-## 它真的是插入排序吗？
+## 它真的是插入排序吗？ { #is-this-really-insertion-sort }
 
 <!--
 Insertion sort is _defined_ to be an in-place sorting algorithm.
@@ -839,7 +839,7 @@ When running `sort --shared`, the array is copied as needed to preserve the pure
 ## Other Opportunities for Mutation
 -->
 
-## 其他可变性的机会
+## 其他可变性的机会 { #other-opportunities-for-mutation }
 
 <!--
 The use of mutation instead of copying when references are unique is not limited to array update operators.
@@ -857,7 +857,7 @@ Lean 还会尝试「回收」引用计数即将降至零的构造函数，重新
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
  * Write a function that reverses arrays. Test that if the input array has a reference count of one, then your function does not allocate a new array.

--- a/functional-programming-lean/src/programs-proofs/special-types.md
+++ b/functional-programming-lean/src/programs-proofs/special-types.md
@@ -2,7 +2,7 @@
 # Special Types
 -->
 
-# 特殊类型
+# 特殊类型 { #special-types }
 
 <!--
 Understanding the representation of data in memory is very important.
@@ -117,7 +117,7 @@ The following types have special representations:
 ## Exercise
 -->
 
-## 练习
+## 练习 { #exercise }
 
 <!--
 The [definition of `Pos`](../type-classes/pos.html) does not take advantage of Lean's compilation of `Nat` to an efficient type.

--- a/functional-programming-lean/src/programs-proofs/summary.md
+++ b/functional-programming-lean/src/programs-proofs/summary.md
@@ -2,13 +2,13 @@
 # Summary
 -->
 
-# 总结
+# 总结 { #summary }
 
 <!--
 ## Tail Recursion
 -->
 
-## 尾递归
+## 尾递归 { #tail-recursion }
 
 <!--
 Tail recursion is recursion in which the results of recursive calls are returned immediately, rather than being used in some other way.
@@ -43,7 +43,7 @@ In other words, two functions that each end with a tail call to the other will n
 ## Reference Counting and In-Place Updates
 -->
 
-## 引用计数与原地更新
+## 引用计数与原地更新 { #reference-counting-and-in-place-updates }
 
 <!--
 Rather than using a tracing garbage collector, as is done in Java, C#, and most JavaScript implementations, Lean uses reference counting for memory management.
@@ -81,7 +81,7 @@ The debugging helper `dbgTraceIfShared` can be used at key locations in the prog
 ## Proving Programs Correct
 -->
 
-## 证明程序的正确性
+## 证明程序的正确性 { #proving-programs-correct }
 
 <!--
 Rewriting a program in accumulator-passing style, or making other transformations that make it run faster, can also make it more difficult to understand.
@@ -115,7 +115,7 @@ In particular, to prove that a function is equivalent to an accumulator-passing 
 ## Safe Array Indices
 -->
 
-## 安全的数组索引
+## 安全的数组索引 { #safe-array-indices }
 
 <!--
 The type `Fin n` represents natural numbers that are strictly less than `n`.
@@ -148,7 +148,7 @@ Lean 为 `Fin` 提供了大多数有用的数字类型类的实例。`Fin` 的 `
 ## Provisional Proofs
 -->
 
-## 临时性证明
+## 临时性证明 { #provisional-proofs }
 
 <!--
 Sometimes, it can be useful to pretend that a statement is proved without actually doing the work of proving it.
@@ -186,7 +186,7 @@ Using `sorry` is convenient during development, but keeping it in the code is da
 ## Proving Termination
 -->
 
-## 停机证明
+## 停机证明 { #proving-termination }
 
 <!--
 When a recursive function does not use structural recursion, Lean cannot automatically determine that it terminates.

--- a/functional-programming-lean/src/programs-proofs/tail-recursion-proofs.md
+++ b/functional-programming-lean/src/programs-proofs/tail-recursion-proofs.md
@@ -2,7 +2,7 @@
 # Proving Equivalence
 -->
 
-# 证明等价
+# 证明等价 { #proving-equivalence }
 
 <!--
 Programs that have been rewritten to use tail recursion and an accumulator can look quite different from the original program.
@@ -18,7 +18,7 @@ After testing both versions of the program on examples to rule out simple bugs, 
 ## Proving `sum` Equal
 -->
 
-## 证明 `sum` 相等
+## 证明 `sum` 相等 { #proving-sum-equal }
 
 <!--
 To prove that both versions of `sum` are equal, begin by writing the theorem statement with a stub proof:
@@ -212,7 +212,7 @@ In other words, this proof is stuck.
 ## A Second Attempt
 -->
 
-## 第二次尝试
+## 第二次尝试 { #a-second-attempt }
 
 <!--
 Rather than attempting to muddle through the proof, it's time to take a step back and think.
@@ -548,13 +548,13 @@ This may require rewriting the goal to make the neutral initial accumulator valu
 ## Exercise
 -->
 
-## 练习
+## 练习 { #exercise }
 
 <!--
 ### Warming Up
 -->
 
-### 热身
+### 热身 { #warming-up }
 
 <!--
 Write your own proofs for `Nat.zero_add`, `Nat.add_assoc`, and `Nat.add_comm` using the `induction` tactic.
@@ -566,13 +566,13 @@ Write your own proofs for `Nat.zero_add`, `Nat.add_assoc`, and `Nat.add_comm` us
 ### More Accumulator Proofs
 -->
 
-### 更多累加器证明
+### 更多累加器证明 { #more-accumulator-proofs }
 
 <!--
 #### Reversing Lists
 -->
 
-#### 反转列表
+#### 反转列表 { #reversing-lists }
 
 <!--
 Adapt the proof for `sum` into a proof for `NonTail.reverse` and `Tail.reverse`.
@@ -613,7 +613,7 @@ This results in a suitable goal:
 #### Factorial
 -->
 
-#### 阶乘
+#### 阶乘 { #factorial }
 
 <!--
 Prove that `NonTail.factorial` from the exercises in the previous section is equal to your tail-recursive solution by finding the relationship between the accumulator and the result and proving a suitable helper theorem.

--- a/functional-programming-lean/src/programs-proofs/tail-recursion.md
+++ b/functional-programming-lean/src/programs-proofs/tail-recursion.md
@@ -2,7 +2,7 @@
 # Tail Recursion
 -->
 
-# 尾递归
+# 尾递归 { #tail-recursion }
 
 <!--
 While Lean's `do`-notation makes it possible to use traditional loop syntax such as `for` and `while`, these constructs are translated behind the scenes to invocations of recursive functions.
@@ -166,7 +166,7 @@ At each recursive call, the function argument on the stack is simply replaced wi
 ## Tail and Non-Tail Positions
 -->
 
-## 尾部与非尾部位置
+## 尾部与非尾部位置 { #tail-and-non-tail-positions }
 
 <!--
 The reason why `Tail.sumHelper` is tail recursive is that the recursive call is in _tail position_.
@@ -227,7 +227,7 @@ While it is certainly possible to eliminate a tail call to some other function, 
 ## Reversing Lists
 -->
 
-## 反转列表
+## 反转列表 { #reversing-lists }
 
 <!--
 The function `NonTail.reverse` reverses lists by appending the head of each sub-list to the end of the result:
@@ -298,7 +298,7 @@ Appending `[x]` after the result of the recursion in `NonTail.reverse` is analog
 ## Multiple Recursive Calls
 -->
 
-## 多个递归调用
+## 多个递归调用 { #multiple-recursive-calls }
 
 <!--
 In the definition of `BinTree.mirror`, there are two recursive calls:
@@ -337,7 +337,7 @@ There are systematic techniques for making these functions tail-recursive, such 
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 Translate each of the following non-tail-recursive functions into accumulator-passing tail-recursive functions:

--- a/functional-programming-lean/src/props-proofs-indexing.md
+++ b/functional-programming-lean/src/props-proofs-indexing.md
@@ -2,7 +2,7 @@
 # Interlude: Propositions, Proofs, and Indexing
 -->
 
-# 插曲：命题、证明与索引
+# 插曲：命题、证明与索引 { #interlude-propositions-proofs-and-indexing }
 
 <!--
 Like many languages, Lean uses square brackets for indexing into arrays and lists.
@@ -59,7 +59,7 @@ Understanding how this works requires an understanding of three key ideas: propo
 ## Propositions and Proofs
 -->
 
-## 命题与证明
+## 命题与证明 { #propositions-and-proofs }
 
 <!--
 A _proposition_ is a statement that can be true or false.
@@ -206,7 +206,7 @@ The prior example could be rewritten as follows:
 ## Tactics
 -->
 
-## 策略
+## 策略 { #tactics }
 
 <!--
 Proofs are normally written using _tactics_, rather than by providing evidence directly.
@@ -273,7 +273,7 @@ This tactic is `simp`, configured to take certain arithmetic identities into acc
 ## Connectives
 -->
 
-## 连词
+## 连词 { #connectives }
 
 <!--
 The basic building blocks of logic, such as "and", "or", "true", "false", and "not", are called _logical connectives_.
@@ -378,7 +378,7 @@ The `simp` 策略可以证明使用了这些连接词的定理。例如：
 ## Evidence as Arguments
 -->
 
-## 证据作为参数
+## 证据作为参数 { #evidence-as-arguments }
 
 <!--
 While `simp` does a great job proving propositions that involve equalities and inequalities of specific numbers, it is not very good at proving statements that involve variables.
@@ -444,7 +444,7 @@ In these cases, `by simp` can construct the evidence automatically:
 ## Indexing Without Evidence
 -->
 
-## 无证据索引
+## 无证据索引 { #indexing-without-evidence }
 
 <!--
 In cases where it's not practical to prove that an indexing operation is in bounds, there are other alternatives.
@@ -499,7 +499,7 @@ Because code that is run with `#eval` runs in the context of the Lean compiler, 
 ## Messages You May Meet
 -->
 
-## 你可能会遇到的信息
+## 你可能会遇到的信息 { #messages-you-may-meet }
 
 <!--
 In addition to the error that occurs when Lean is unable to find compile-time evidence that an indexing operation is safe, polymorphic functions that use unsafe indexing may produce the following message:
@@ -564,7 +564,7 @@ This error message results from having Lean attempt to treat `woodlandCritters` 
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 * Prove the following theorems using `rfl`: `2 + 3 = 5`, `15 - 8 = 7`, `"Hello, ".append "world" = "Hello, world"`. What happens if `rfl` is used to prove `5 < 18`? Why?

--- a/functional-programming-lean/src/tactics-induction-proofs.md
+++ b/functional-programming-lean/src/tactics-induction-proofs.md
@@ -1,6 +1,6 @@
-## 小插曲：策略，归纳与证明
+# 小插曲：策略，归纳与证明 { #interlude-tactics-induction-and-proofs }
 
-### 一个关于证明与用户界面的说明
+## 一个关于证明与用户界面的说明 { #a-note-on-proofs-and-user-interfaces }
 <!--
 This book presents the process of writing proofs as if they are written in one go and submitted to Lean, which then replies with error messages that describe what remains to be done. The actual process of interacting with Lean is much more pleasant. Lean provides information about the proof as the cursor is moved through it and there are a number of interactive features that make proving easier. Please consult the documentation of your Lean development environment for more information.
 -->
@@ -11,7 +11,7 @@ The approach in this book that focuses on incrementally building a proof and sho
 -->
 本书中的方法侧重于逐步构建证明并显示产生的消息，这展示了 Lean 在编写证明时提供的各种互动反馈，尽管这比专家使用的过程慢得多。同时，看到不完整的证明逐步趋向完整是一种对证明有益的视角。随着您编写证明技能的提高，Lean 的反馈将不再感觉像错误，而更像是对您自己思维过程的支持。学习互动方法非常重要。
 
-### 递归和归纳
+## 递归和归纳 { #recursion-and-induction }
 <!--
 The functions plusR_succ_left and plusR_zero_left from the preceding chapter can be seen from two perspectives. On the one hand, they are recursive functions that build up evidence for a proposition, just as other recursive functions might construct a list, a string, or any other data structure. On the other, they also correspond to proofs by mathematical induction.
 -->
@@ -33,7 +33,7 @@ Because it's impossible to check the statement for every natural number, inducti
 -->
 因为我们不可能对**每个**自然数进行检查，归纳提供了一种手段来编写原则上可以扩展到任何特定自然数的证明。例如，如果需要对数字 3 进行具体证明，那么可以首先使用基本情况，然后归纳步骤三次，分别证明命题对 0、1、2，最后对 3 成立。因此，它证明了该命题对所有自然数成立。
 
-### 归纳策略
+## 归纳策略 { #the-induction-tactic }
 <!--
 Writing proofs by induction as recursive functions that use helpers such as congrArg does not always do a good job of expressing the intentions behind the proof. While recursive functions indeed have the structure of induction, they should probably be viewed as an encoding of a proof. Furthermore, Lean's tactic system provides a number of opportunities to automate the construction of a proof that are not available when writing the recursive function explicitly. Lean provides an induction tactic that can carry out an entire proof by induction in a single tactic block. Behind the scenes, Lean constructs the recursive function that corresponds the use of induction.
 -->
@@ -203,7 +203,7 @@ This rewrite makes both sides of the equation identical, and Lean takes care of 
 -->
 这个重写使得等式的两边相同，Lean 会自己处理 **rfl**。证毕。
 
-### 策略高尔夫
+## 策略高尔夫 { #tactic-golf }
 <!--
 So far, the tactic language has not shown its true value. The above proof is no shorter than the recursive function; it's merely written in a domain-specific language instead of the full Lean language. But proofs with tactics can be shorter, easier, and more maintainable. Just as a lower score is better in the game of golf, a shorter proof is better in the game of tactic golf.
 
@@ -330,7 +330,7 @@ For beginners, this proof is not easier to read. However, a common pattern for e
 -->
 对于初学者来说，这个证明并不容易阅读。然而，专家用户的常见模式是使用像 **simp** 这样的强大策略处理一些简单情况，使他们可以将证明的文本集中在有趣的情况下。此外，这些证明在面对函数和数据类型的小变化时往往更稳健。策略高尔夫游戏是培养编写证明时的良好品味和风格的有用部分。
 
-### 其他数据类型的归纳
+## 其他数据类型的归纳 { #induction-on-other-datatypes }
 <!--
 Mathematical induction proves a statement for natural numbers by providing a base case for Nat.zero and an induction step for Nat.succ. The principle of induction is also valid for other datatypes. Constructors without recursive arguments form the base cases, while constructors with recursive arguments form the induction steps. The ability to carry out proofs by induction is the very reason why they are called inductive datatypes.
 -->
@@ -500,7 +500,7 @@ theorem BinTree.mirror_count (t : BinTree α) : t.mirror.count = t.count := by
   induction t <;> simp_arith [BinTree.mirror, BinTree.count, *]
 ```
 
-### 练习
+## 练习 { #exercises }
 
 <!--
 1. Prove plusR_succ_left using the induction ... with tactic.
@@ -510,4 +510,3 @@ theorem BinTree.mirror_count (t : BinTree α) : t.mirror.count = t.count := by
 1. 使用**induction...with** 策略证明 **plusR_succ_left**。
 2. 重写 **plus_succ_left** 的证明，使用 **<;>** 并写成一行。
 3. 使用列表归纳证明列表追加是结合的：**theorem List.append_assoc (xs ys zs : List α) : xs ++ (ys ++ zs) = (xs ++ ys) ++ zs**
-

--- a/functional-programming-lean/src/title.md
+++ b/functional-programming-lean/src/title.md
@@ -2,7 +2,7 @@
 # Functional Programming in Lean
 -->
 
-# Lean 函数式编程
+# Lean 函数式编程 { #functional-programming-in-lean }
 
 <!--
 *by David Thrane Christiansen*
@@ -26,7 +26,7 @@ This is a free book on using Lean 4 as a programming language. All code samples 
 ## Release history
 -->
 
-## 发行历史
+## 发行历史 { #release-history }
 
 <!--
 ### January, 2024
@@ -34,7 +34,7 @@ This is a free book on using Lean 4 as a programming language. All code samples 
 This is a minor bugfix release that fixes a regression in an example program.
 -->
 
-### 2024 年 1 月
+### 2024 年 1 月 { #january- }
 
 这是一个次要的 bug 修复版本，修复了示例程序中一个回退问题。
 
@@ -44,7 +44,7 @@ This is a minor bugfix release that fixes a regression in an example program.
 In this first maintenance release, a number of smaller issues were fixed and the text was brought up to date with the latest release of Lean.
 -->
 
-### 2023 年 10 月
+### 2023 年 10 月 { #october- }
 
 在首次维护版本中，修复了许多较小的错误，并根据 Lean 的最新版本更新了文本。
 
@@ -55,7 +55,7 @@ In this first maintenance release, a number of smaller issues were fixed and the
 The book is now complete! Compared to the April pre-release, many small details have been improved and minor mistakes have been fixed.
 -->
 
-### 2023 年 5 月
+### 2023 年 5 月 { #may- }
 
 本书现已完成！与 4 月份的预发布版本相比，许多小细节得到了改进，并修复了一些小错误。
 
@@ -66,7 +66,7 @@ This release adds an interlude on writing proofs with tactics as well as a final
 This is the last release prior to the final release.
 -->
 
-### 2023 年 4 月
+### 2023 年 4 月 { #april- }
 
 此版本添加了关于使用策略编写证明的插曲，以及添加了将性能和成本模型的讨论，与停机证明和程序等价性证明相结合的最后一章。这是最终版本前的最后一个版本。
 
@@ -76,7 +76,7 @@ This is the last release prior to the final release.
 This release adds a chapter on programming with dependent types and indexed families.
 -->
 
-### 2023 年 3 月
+### 2023 年 3 月 { #march- }
 
 此版本添加了关于使用依值类型和索引族编程的章节。
 
@@ -86,7 +86,7 @@ This release adds a chapter on programming with dependent types and indexed fami
 This release adds a chapter on monad transformers that includes a description of the imperative features that are available in `do`-notation.
 -->
 
-### 2023 年 1 月
+### 2023 年 1 月 { #january- }
 
 此版本添加了关于单子变换器的章节，其中包括对 `do`-记法中可用的命令式特性的描述。
 
@@ -98,7 +98,7 @@ This is accompanied with improvements to the description of monads.
 The December 2022 release was delayed until January 2023 due to winter holidays.
 -->
 
-### 2022 年 12 月
+### 2022 年 12 月 { #december- }
 
 此版本添加了关于应用函子的章节，此外还更加详细地描述了结构和类型类。此外改进了对单子的描述。由于冬季假期，2022 年 12 月版本被推迟到 2023 年 1 月。
 
@@ -108,7 +108,7 @@ The December 2022 release was delayed until January 2023 due to winter holidays.
 This release adds a chapter on programming with monads. Additionally, the example of using JSON in the coercions section has been updated to include the complete code.
 -->
 
-### 2022 年 11 月
+### 2022 年 11 月 { #november- }
 
 此版本添加了关于使用单子编程的章节。此外，强制转换一节中使用 JSON 的示例已更新为包含完整代码。
 <!--
@@ -117,7 +117,7 @@ This release adds a chapter on programming with monads. Additionally, the exampl
 This release completes the chapter on type classes. In addition, a short interlude introducing propositions, proofs, and tactics has been added just before the chapter on type classes, because a small amount of familiarity with the concepts helps to understand some of the standard library type classes.
 -->
 
-### 2022 年 10 月
+### 2022 年 10 月 { #october- }
 
 此版本完成了类型类的章节。此外，在类型类章节之前添加了一个简短的插曲，介绍了命题、证明和策略，因为简单了解一下这些概念有助于理解一些标准库中的类型类。
 
@@ -127,7 +127,7 @@ This release completes the chapter on type classes. In addition, a short interlu
 This release adds the first half of a chapter on type classes, which are Lean's mechanism for overloading operators and an important means of organizing code and structuring libraries. Additionally, the second chapter has been updated to account for changes in Lean's stream API.
 -->
 
-### 2022 年 9 月
+### 2022 年 9 月 { #september- }
 
 此版本添加了一个关于类型类的章节的前半部分，这是 Lean 的运算符重载机制，也是组织代码和构建函数库的重要手段。此外，还更新了第二章以适应 Lean 中 Stream 流 API 的变化。
 
@@ -137,7 +137,7 @@ This release adds the first half of a chapter on type classes, which are Lean's 
 This third public release adds a second chapter, which describes compiling and running programs along with Lean's model for side effects.
 -->
 
-### 2022 年 8 月
+### 2022 年 8 月 { #august- }
 
 第三次公开发布增加了第二章，其中描述了编译和运行程序以及 Lean 的副作用模型。
 
@@ -147,7 +147,7 @@ This third public release adds a second chapter, which describes compiling and r
 The second public release completes the first chapter.
 -->
 
-### 2022 年 7 月
+### 2022 年 7 月 { #july- }
 
 第二次公开发布，完成了第一章。
 
@@ -157,7 +157,7 @@ The second public release completes the first chapter.
 This was the first public release, consisting of an introduction and part of the first chapter.
 -->
 
-### 2022 年 6 月
+### 2022 年 6 月 { #june- }
 
 这是第一次公开发布，包括引言和第一章的一部分。
 
@@ -165,7 +165,7 @@ This was the first public release, consisting of an introduction and part of the
 ## About the Author
 -->
 
-## 关于作者
+## 关于作者 { #about-the-author }
 
 <!--
 David Thrane Christiansen has been using functional languages for twenty years, and dependent types for ten.
@@ -184,6 +184,6 @@ David Thrane Christiansen 已使用函数式语言二十年，并使用依值类
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 -->
 
-## 授权许可
+## 授权许可 { #license }
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/deed.zh-hans"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />本作品采用<a rel="license" href="http://creativecommons.org/licenses/by/4.0/deed.zh-hans">知识共享-署名 4.0 国际许可协议</a>授权。

--- a/functional-programming-lean/src/type-classes.md
+++ b/functional-programming-lean/src/type-classes.md
@@ -2,7 +2,7 @@
 # Overloading and Type Classes
 -->
 
-# 重载与类型类
+# 重载与类型类 { #overloading-and-type-classes }
 
 <!--
 In many languages, the built-in datatypes get special treatment.
@@ -80,7 +80,3 @@ Lean 的类型类更像是 Java 或 C# 中的 **接口（interface）**。
 类似地，类型类的实例也很像 Java 或 C# 中描述实现了的接口的类，而不是 Java 或 C# 中类的实例。
 不像 Java 或 C# 的接口，对于一个类型，该类型的作者并不能访问的类型类也可以给这个类型实例。
 从这种意义上讲，这和 Rust 的 traits 很像。
-
-
-
-

--- a/functional-programming-lean/src/type-classes/coercion.md
+++ b/functional-programming-lean/src/type-classes/coercion.md
@@ -2,7 +2,7 @@
 # Coercions
 -->
 
-# 强制转换
+# 强制转换 { #coercions }
 
 <!--
 In mathematics, it is common to use the same symbol to stand for different aspects of some object in different contexts.
@@ -30,7 +30,7 @@ Unlike Java, C, and Kotlin, the coercions are extensible by defining instances o
 ## Positive Numbers
 -->
 
-## 正数
+## 正数 { #positive-numbers }
 
 <!--
 For example, every positive number corresponds to a natural number.
@@ -98,7 +98,7 @@ Using `#check` shows the result of the instance search that was used behind the 
 ## Chaining Coercions
 -->
 
-## 链式强制转换
+## 链式强制转换 { #chaining-coercions }
 
 <!--
 When searching for coercions, Lean will attempt to assemble a coercion out of a chain of smaller coercions.
@@ -216,7 +216,7 @@ It can also make the programmer's intentions more clear.
 ## Non-Empty Lists and Dependent Coercions
 -->
 
-## 非空列表与依值强制转换
+## 非空列表与依值强制转换 { #non-empty-lists-and-dependent-coercions }
 
 <!--
 An instance of `Coe α β` makes sense when the type `β` has a value that can represent each value from the type `α`.
@@ -265,7 +265,7 @@ For example, any `List` that is not actually empty can be coerced to a `NonEmpty
 ## Coercing to Types
 -->
 
-## 强制转换为类型（*本节中 sort 的翻译待讨论*）
+## 强制转换为类型（*本节中 sort 的翻译待讨论*） { #coercing-to-types }
 
 <!--
 In mathematics, it is common to have a concept that consists of a set equipped with additional structure.
@@ -343,7 +343,7 @@ Rather than have two kinds of `if` expression, the Lean standard library defines
 -->
 
 另一个有用的 `CoeSort` 使用场景是它可以让 `Bool` 和 `Prop` 建立联系。
-就像在[有序性和等价性那一节](./standard-classes#相等性与有序性)我们提到的，Lean 的 `if` 表达式需要条件为一个可判定的命题而不是一个 `Bool`。
+就像在[有序性和等价性那一节](./standard-classes#equality-and-ordering)我们提到的，Lean 的 `if` 表达式需要条件为一个可判定的命题而不是一个 `Bool`。
 然而，程序通常需要能够根据布尔值进行分支。
 Lean 标准库并没有定义两种 `if` 表达式，而是定义了一种从 `Bool` 到命题的强制转换，即该 `Bool` 值等于 `true`：
 ```lean
@@ -359,7 +359,7 @@ In this case, the sort in question is `Prop` rather than `Type`.
 ## Coercing to Functions
 -->
 
-## 强制转换为函数 （*本节翻译需要润色*）
+## 强制转换为函数 （*本节翻译需要润色*） { #coercing-to-functions }
 
 <!--
 Many datatypes that occur regularly in programming consist of a function along with some extra information about it.
@@ -497,7 +497,7 @@ The serializer can be passed directly to `buildResponse`:
 ### Aside: JSON as a String
 -->
 
-### 附注：将 JSON 表示为字符串
+### 附注：将 JSON 表示为字符串 { #aside-json-as-a-string }
 
 <!--
 It can be a bit difficult to understand JSON when encoded as Lean objects.
@@ -587,7 +587,7 @@ With this definition, the output of serialization is easier to read:
 ## Messages You May Meet
 -->
 
-## 可能会遇到的问题
+## 可能会遇到的问题 { #messages-you-may-meet }
 
 <!--
 Natural number literals are overloaded with the `OfNat` type class.
@@ -607,7 +607,7 @@ Because coercions fire in cases where types don't match, rather than in cases of
 ## Design Considerations
 -->
 
-## 设计原则
+## 设计原则 { #design-considerations }
 
 <!--
 Coercions are a powerful tool that should be used responsibly.
@@ -673,6 +673,4 @@ This means that there is still an important difference between expressions that 
 
 最后，强制转换不会在字段访问符号的上下文中应用。
 这意味着需要强制转换的表达式与不需要强制转换的表达式之间仍然存在重要区别，而这个区别对用户来说是肉眼可见的。
-
-
 

--- a/functional-programming-lean/src/type-classes/conveniences.md
+++ b/functional-programming-lean/src/type-classes/conveniences.md
@@ -2,13 +2,13 @@
 # Additional Conveniences
 -->
 
-# 其他便利功能
+# 其他便利功能 { #additional-conveniences }
 
 <!--
 ## Constructor Syntax for Instances
 -->
 
-## 实例的构造子语法
+## 实例的构造子语法 { #constructor-syntax-for-instances }
 
 <!--
 Behind the scenes, type classes are structure types and instances are values of these types.
@@ -61,7 +61,7 @@ Placing a call to this function after `:=` in an instance declaration is the eas
 ## Examples
 -->
 
-## 例子
+## 例子 { #examples }
 
 <!--
 When experimenting with Lean code, definitions can be more convenient to use than `#eval` or `#check` commands.
@@ -109,4 +109,3 @@ In source files, `example` declarations are best paired with comments that expla
 这会在幕后创建一个函数，这个函数没有名字，也不能被调用。
 此外，这可以用来检查某库中的函数是否可以在任意的或一些类型的未知值上正常工作。
 在源码中，`example` 声明很适合与解释概念的注释搭配使用。
-

--- a/functional-programming-lean/src/type-classes/indexing.md
+++ b/functional-programming-lean/src/type-classes/indexing.md
@@ -2,7 +2,7 @@
 # Arrays and Indexing
 -->
 
-# 数组与索引
+# 数组与索引 { #arrays-and-indexing }
 
 <!--
 The [Interlude](../props-proofs-indexing.md) describes how to use indexing notation in order to look up entries in a list by their position.
@@ -16,7 +16,7 @@ This syntax is also governed by a type class, and it can be used for a variety o
 ## Arrays
 -->
 
-## 数组
+## 数组 { #arrays }
 <!--
 For instance, Lean arrays are much more efficient than linked lists for most purposes.
 In Lean, the type `Array α` is a dynamically-sized array holding values of type `α`, much like a Java `ArrayList`, a C++ `std::vector`, or a Rust `Vec`.
@@ -70,7 +70,7 @@ For instance, `{{#example_in Examples/Classes.lean northernTreesEight}}` results
 ## Non-Empty Lists
 -->
 
-## 非空列表
+## 非空列表 { #non-empty-lists }
 
 <!--
 A datatype that represents non-empty lists can be defined as a structure with a field for the head of the list and a field for the tail, which is an ordinary, potentially empty list:
@@ -188,7 +188,7 @@ This requires techniques for working with proofs and propositions that are descr
 ## Overloading Indexing
 -->
 
-## 重载索引
+## 重载索引 { #overloading-indexing }
 
 <!--
 Indexing notation for a collection type can be overloaded by defining an instance of the `GetElem` type class.

--- a/functional-programming-lean/src/type-classes/out-params.md
+++ b/functional-programming-lean/src/type-classes/out-params.md
@@ -2,7 +2,7 @@
 # Controlling Instance Search
 -->
 
-# 控制实例搜索
+# 控制实例搜索 { #controlling-instance-search }
 
 <!--
 An instance of the `Add` class is sufficient to allow two expressions with type `Pos` to be conveniently added, producing another `Pos`.
@@ -27,7 +27,7 @@ These functions allow natural numbers to be added to positive numbers, but they 
 ## Heterogeneous Overloadings
 -->
 
-## 异质重载
+## 异质重载 { #heterogeneous-overloadings }
 
 <!--
 As mentioned in the section on [overloaded addition](pos.md#overloaded-addition), Lean provides a type class called `HAdd` for overloading addition heterogeneously.
@@ -35,7 +35,7 @@ The `HAdd` class takes three type parameters: the two argument types and the ret
 Instances of `HAdd Nat Pos Pos` and `HAdd Pos Nat Pos` allow ordinary addition notation to be used to mix the types:
 -->
 
-就像在[重载加法](./pos#重载加法)一节提到的，Lean 提供了名为 `HAdd` 的类型类来重载异质加法。
+就像在[重载加法](./pos#overloaded-addition)一节提到的，Lean 提供了名为 `HAdd` 的类型类来重载异质加法。
 `HAdd` 类接受三个类型参数：两个参数的类型和一个返回类型。
 `HAdd Nat Pos Pos` 和 `HAdd Pos Nat Pos` 的实例可以让常规加法符号可以接受不同类型。
 
@@ -127,7 +127,7 @@ However, this solution is not very convenient for users of the positive number l
 ## Output Parameters
 -->
 
-## 输出参数
+## 输出参数 { #output-parameters }
 
 <!--
 This problem can also be solved by declaring `γ` to be an _output parameter_.
@@ -177,7 +177,7 @@ Output parameters can determine other types in the program, and instance search 
 ## Default Instances
 -->
 
-## 默认实例
+## 默认实例 { #default-instances }
 
 <!--
 Deciding whether a parameter is an input or an output controls the circumstances under which Lean will initiate type class search.
@@ -323,7 +323,7 @@ For more information on default instance priorities, please consult the Lean man
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 Define an instance of `HMul (PPoint α) α (PPoint α)` that multiplies both projections by the scalar.

--- a/functional-programming-lean/src/type-classes/polymorphism.md
+++ b/functional-programming-lean/src/type-classes/polymorphism.md
@@ -2,7 +2,7 @@
 # Type Classes and Polymorphism
 -->
 
-# 类型类与多态
+# 类型类与多态 { #type-classes-and-polymorphism }
 
 <!--
 It can be useful to write functions that work for _any_ overloading of a given function.
@@ -24,7 +24,7 @@ It returns an `IO` action.
 ## Checking Polymorphic Functions' Types
 -->
 
-## 对多态函数的类型检查
+## 对多态函数的类型检查 { #checking-polymorphic-functions-types }
 
 <!--
 Checking the type of a function that takes implicit arguments or uses type classes requires the use of some additional syntax.
@@ -74,7 +74,7 @@ For now, ignore these parameters to `Type`.
 ## Defining Polymorphic Functions with Instance Implicits
 -->
 
-## 定义含隐式实例的多态函数
+## 定义含隐式实例的多态函数 { #defining-polymorphic-functions-with-instance-implicits }
 
 <!--
 A function that sums all entries in a list needs two instances: `Add` allows the entries to be added, and an `OfNat` instance for `0` provides a sensible value to return for the empty list:
@@ -197,7 +197,7 @@ API的客户端无需手工组合所有必要的部分，从而使用户从这�
 ## Methods and Implicit Arguments
 -->
 
-## 方法与隐式参数
+## 方法与隐式参数 { #methods-and-implicit-arguments }
 
 
 <!--
@@ -264,27 +264,27 @@ Thus, in these cases, Lean uses an explicit argument for the class's method.
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 ### Even Number Literals
 -->
 
-### 偶数数字字面量
+### 偶数数字字面量 { #even-number-literals }
 
 <!--
 Write an instance of `OfNat` for the even number datatype from the [previous section's exercises](pos.md#even-numbers) that uses recursive instance search.
 For the base instance, it is necessary to write `OfNat Even Nat.zero` instead of `OfNat Even 0`.
 -->
 
-为[上一节的练习题](pos#偶数)中的偶数数据类型写一个使用递归实例搜索的 `OfNat` 实例。
+为[上一节的练习题](pos#even-numbers)中的偶数数据类型写一个使用递归实例搜索的 `OfNat` 实例。
 对于基本实例，有必要编写 `OfNat Even Nat.zero` 而不是 `OfNat Even 0`。
 
 <!--
 ### Recursive Instance Search Depth
 -->
 
-### 递归实例搜索深度
+### 递归实例搜索深度 { #recursive-instance-search-depth }
 
 <!--
 There is a limit to how many times the Lean compiler will attempt a recursive instance search.

--- a/functional-programming-lean/src/type-classes/pos.md
+++ b/functional-programming-lean/src/type-classes/pos.md
@@ -2,7 +2,7 @@
 # Positive Numbers
 -->
 
-# 正数
+# 正数 { #positive-numbers }
 
 <!--
 In some applications, only positive numbers make sense.
@@ -79,7 +79,7 @@ This indicates that the error is due to an overloaded operation that has not bee
 ## Classes and Instances
 -->
 
-## 类与实例
+## 类与实例 { #classes-and-instances }
 
 <!--
 A type class consists of a name, some parameters, and a collection of _methods_.
@@ -214,7 +214,7 @@ These errors mean that Lean was unable to find an instance for a given type clas
 ## Overloaded Addition
 -->
 
-## 重载加法
+## 重载加法 { #overloaded-addition }
 
 <!--
 Lean's built-in addition operator is syntactic sugar for a type class called `HAdd`, which flexibly allows the arguments to addition to have different types.
@@ -252,7 +252,7 @@ Defining an instance of `Add Pos` allows `Pos` values to use ordinary addition s
 ## Conversion to Strings
 -->
 
-## 转换为字符串
+## 转换为字符串 { #conversion-to-strings }
 
 <!--
 Another useful built-in class is called `ToString`.
@@ -262,7 +262,7 @@ For example, a `ToString` instance is used when a value occurs in an interpolate
 
 另一个有用的内置类叫做 `ToString`。
 `ToString` 的实例提供了一种将给定类型转换为字符串的标准方式。
-例如，当值出现在插值字符串中时，会使用 ToString 实例。它决定了在[`IO` 的描述开始处](../hello-world/running-a-program#运行程序)使用的 `IO.println` 函数如何显示一个值。
+例如，当值出现在插值字符串中时，会使用 ToString 实例。它决定了在[`IO` 的描述开始处](../hello-world/running-a-program#running-a-program)使用的 `IO.println` 函数如何显示一个值。
 
 <!--
 For example, one way to convert a `Pos` into a `String` is to reveal its inner structure.
@@ -327,7 +327,7 @@ Additionally, if a type has a `ToString` instance, then it can be used to displa
 ## Overloaded Multiplication
 -->
 
-## 重载乘法运算符
+## 重载乘法运算符 { #overloaded-multiplication }
 
 <!--
 For multiplication, there is a type class called `HMul` that allows mixed argument types, just like `HAdd`.
@@ -365,7 +365,7 @@ With this instance, multiplication works as expected:
 ## Literal Numbers
 -->
 
-## 数字字面量
+## 数字字面量 { #literal-numbers }
 
 <!--
 It is quite inconvenient to write out a sequence of constructors for positive numbers.
@@ -502,13 +502,13 @@ This makes it possible to use natural number literals for positive numbers, but 
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
 ### Another Representation
 -->
 
-### 另一种表示
+### 另一种表示 { #another-representation }
 
 <!--
 An alternative way to represent a positive number is as the successor of some `Nat`.
@@ -531,7 +531,7 @@ Define instances of `Add`, `Mul`, `ToString`, and `OfNat` that allow this versio
 ### Even Numbers
 -->
 
-### 偶数
+### 偶数 { #even-numbers }
 
 <!--
 Define a datatype that represents only even numbers. Define instances of `Add`, `Mul`, and `ToString` that allow it to be used conveniently.
@@ -545,7 +545,7 @@ Define a datatype that represents only even numbers. Define instances of `Add`, 
 ### HTTP Requests
 -->
 
-### HTTP 请求
+### HTTP 请求 { #http-requests }
 
 <!--
 An HTTP request begins with an identification of a HTTP method, such as `GET` or `POST`, along with a URI and an HTTP version.

--- a/functional-programming-lean/src/type-classes/standard-classes.md
+++ b/functional-programming-lean/src/type-classes/standard-classes.md
@@ -2,7 +2,7 @@
 # Standard Classes
 -->
 
-# 标准类
+# 标准类 { #standard-classes }
 
 <!--
 This section presents a variety of operators and functions that can be overloaded using type classes in Lean.
@@ -18,7 +18,7 @@ Unlike C++, infix operators in Lean are defined as abbreviations for named funct
 ## Arithmetic
 -->
 
-## 算术符号
+## 算术符号 { #arithmetic }
 
 <!--
 Most arithmetic operators are available in a heterogeneous form, where the arguments may have different type and an output parameter decides the type of the resulting expression.
@@ -47,7 +47,7 @@ The following arithmetic operators are overloaded:
 ## Bitwise Operators
 -->
 
-## 位运算符
+## 位运算符 { #bitwise-operators }
 
 <!--
 Lean contains a number of standard bitwise operators that are overloaded using type classes.
@@ -78,7 +78,7 @@ Because the names `And` and `Or` are already taken as the names of logical conne
 ## Equality and Ordering
 -->
 
-## 相等性与有序性
+## 相等性与有序性 { #equality-and-ordering }
 
 <!--
 Testing equality of two values typically uses the `BEq` class, which is short for "Boolean equality".
@@ -242,7 +242,7 @@ In situations where `compareTo` would be the right approach in Java, use `Ord.co
 ## Hashing
 -->
 
-## 哈希
+## 哈希 { #hashing }
 
 <!--
 Java and C# have `hashCode` and `GetHashCode` methods, respectively, that compute a hash of a value for use in data structures such as hash tables.
@@ -304,7 +304,7 @@ Binary trees use both recursion and recursive instance search in the implementat
 ## Deriving Standard Classes
 -->
 
-## 派生标准类
+## 派生标准类 { #deriving-standard-classes }
 
 <!--
 Instance of classes like `BEq` and `Hashable` are often quite tedious to implement by hand.
@@ -371,7 +371,7 @@ Changesets involving updates to datatypes are easier to read without line after 
 实例派生除了在开发效率和代码可读性上有很大的优势外，它也使得代码更易于维护，因为实例会随着类型定义的变化而更新。
 对数据类型的一系列更新更易于阅读，因为不需要一行又一行地对相等性测试和哈希计算进行公式化的修改。
 
-## Appending
+## Appending { #appending }
 
 <!--
 Many datatypes have some sort of append operator.
@@ -440,7 +440,7 @@ results in
 ## Functors
 -->
 
-## 函子
+## 函子 { #functors }
 
 <!--
 A polymorphic type is a _functor_ if it has an overload for a function named `map` that transforms every element contained in it by a function.
@@ -598,7 +598,7 @@ These rules prevent implementations of `map` that move the data around or delete
 ## Messages You May Meet
 -->
 
-## 你也许会遇到的问题
+## 你也许会遇到的问题 { #messages-you-may-meet }
 
 <!--
 Lean is not able to derive instances for all classes.
@@ -632,7 +632,7 @@ This message, however, means that no code generator was found for `ToString`.
 ## Exercises
 -->
 
-## 练习
+## 练习 { #exercises }
 
 <!--
  * Write an instance of `HAppend (List α) (NonEmptyList α) (NonEmptyList α)` and test it.

--- a/functional-programming-lean/src/type-classes/summary.md
+++ b/functional-programming-lean/src/type-classes/summary.md
@@ -2,13 +2,13 @@
 # Summary
 -->
 
-# 总结
+# 总结 { #summary }
 
 <!--
 ## Type Classes and Overloading
 -->
 
-## 类型类和重载
+## 类型类和重载 { #type-classes-and-overloading }
 
 <!--
 Type classes are Lean's mechanism for overloading functions and operators.
@@ -70,7 +70,7 @@ When an instance is a default instance, then it will be chosen as a fallback whe
 ## Type Classes for Common Syntax
 -->
 
-## 常见语法的类型类
+## 常见语法的类型类 { #type-classes-for-common-syntax }
 
 <!--
 Most infix operators in Lean are overridden with a type class.
@@ -100,7 +100,7 @@ When Lean is unable to check that list or array access operations are in bounds 
 ## Functors
 -->
 
-## 函子
+## 函子 { #functors }
 
 <!--
 A functor is a polymorphic type that supports a mapping operation.
@@ -125,7 +125,7 @@ Lean 中的 `Functor` 类型类还包含了额外的默认方法，这些方法�
 ## Deriving Instances
 -->
 
-## 派生实例
+## 派生实例 { #deriving-instances }
 
 <!--
 Many type classes have very standard implementations.
@@ -151,7 +151,7 @@ Because each class for which instances can be derived requires special handling,
 ## Coercions
 -->
 
-## 强制转换
+## 强制转换 { #coercions }
 <!--
 Coercions allow Lean to recover from what would normally be a compile-time error by inserting a call to a function that transforms data from one type to another.
 For example, the coercion from any type `α` to the type `Option α` allows values to be written directly, rather than with the `some` constructor, making `Option` work more like nullable types from object-oriented languages.


### PR DESCRIPTION
这个 PR 做了这些事情：
1. 提供了一个脚本 [functional-programming-lean/scripts/sync-title-id.py](https://github.com/Lean-zh/fp-lean-zh/compare/master...Hagb:fp-lean-zh:master?expand=1#diff-5f32314078edb5ec44e5f60c3024f581be9e4dacf3d6d4c878c014864af5746f) 来将原文的章节标题的 id 同步到译文（其语法见于 https://github.com/rust-lang/mdBook/blob/v0.4.30/guide/src/format/markdown.md#heading-attributes ，需要更新 mdbook 到 >= 0.4.30 的版本）；
2. 同步过程删除了一些译文中相较原文多出来的大标题，如 [functional-programming-lean/src/introduction.md](https://github.com/Lean-zh/fp-lean-zh/compare/master...Hagb:fp-lean-zh:master?expand=1#diff-5ba9032ff64e5413526febedc3106c72a25ba1c4de2763114a4b547c9145a8e2) 处的 `# 引言`，修复了一些标题级别与原文不对应的情况；
3. 将使用译文作为 fragment identifiers 的超链接改为使用原文 fragment identifiers，如 [functional-programming-lean/src/monads/class.md](https://github.com/Lean-zh/fp-lean-zh/compare/master...Hagb:fp-lean-zh:master?expand=1#diff-bcade81531581ffa30b24d7b5e90da38c343db80d7268d6e5655e614e2c89b8a) 处的
    ```diff
    - 如[本章简介](../monads.md#对树节点编号)所介绍的，`State σ α`表示使用类型为 `σ` 的可变变量，并返回类型为 `α` 的值的程序。
    + 如[本章简介](../monads.md#numbering-tree-nodes)所介绍的，`State σ α`表示使用类型为 `σ` 的可变变量，并返回类型为 `α` 的值的程序。
    ```
效果见于：https://hagb.name/fp-lean-zh/